### PR TITLE
No-docker: pin dependencies, docs, and CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,10 @@
+image: ubuntu
+
+install:
+  # Installing (the non-docker version)
+  - bash -x install_no_docker/install.sh
+
+test_script:
+  - source install_no_docker/load_pcgr.sh
+
+build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,12 @@ python:
   # We don't actually use the Travis Python (since we are on conda), but this keeps it organized.
   - "3.6"
 
-before_install:
-  # Temporal fix for networking problem: https://github.com/travis-ci/travis-ci/issues/1484
-  - echo "127.0.1.1 "`hostname` | sudo tee /etc/hosts
-
-  # The next couple lines fix a crash with multiprocessing on Travis and
-  # are not specific to using Miniconda
-  - sudo rm -rf /dev/shm
-  - sudo ln -s /run/shm /dev/shm
-
-  # Download data bundles
-  # - cd ..
-  # - git clone https://github.com/circulosmeos/gdown.pl
-  # - gdown.pl/gdown.pl https://drive.google.com/file/d/1cGBAmAh5t4miIeRrrd0zHsPCFToOr0Lf/view pcgr.databundle.grch37.tgz
-  # - gzip -dc pcgr.databundle.grch37.tgz | tar xvf -
+## Download data bundles. (skipping this because of lack of disk space on Travis)
+#before_install:
+#  - cd ..
+#  - git clone https://github.com/circulosmeos/gdown.pl
+#  - gdown.pl/gdown.pl https://drive.google.com/file/d/1cGBAmAh5t4miIeRrrd0zHsPCFToOr0Lf/view pcgr.databundle.grch37.tgz
+#  - gzip -dc pcgr.databundle.grch37.tgz | tar xvf -
 
 
 install:
@@ -28,6 +20,7 @@ install:
 
 script:
   - source load_pcgr.sh
+  # (Skipping running an actual test because we don't have enough Travis disk space for full data bundles)
   # - python pcgr.py \
   #   --input_vcf examples/tumor_sample.COAD.vcf.gz \
   #   --input_cna examples/tumor_sample.COAD.cna.tsv \
@@ -37,10 +30,3 @@ script:
   #   examples/pcgr_conf.COAD.toml \
   #   tumor_sample.COAD
   #   --no-docker
-
-
-#notifications:
-#  on_success: always
-#  email: false
-#  slack:
-#    rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ before_install:
   - sudo ln -s /run/shm /dev/shm
 
   # Download data bundles
-  - cd ..
-  - git clone https://github.com/circulosmeos/gdown.pl
-  - gdown.pl/gdown.pl https://drive.google.com/file/d/1cGBAmAh5t4miIeRrrd0zHsPCFToOr0Lf/view pcgr.databundle.grch37.tgz
-  - gzip -dc pcgr.databundle.grch37.tgz | tar xvf -
+  # - cd ..
+  # - git clone https://github.com/circulosmeos/gdown.pl
+  # - gdown.pl/gdown.pl https://drive.google.com/file/d/1cGBAmAh5t4miIeRrrd0zHsPCFToOr0Lf/view pcgr.databundle.grch37.tgz
+  # - gzip -dc pcgr.databundle.grch37.tgz | tar xvf -
 
 
 install:
@@ -27,16 +27,16 @@ install:
 
 
 script:
-  - source install_no_docker/load_pcgr.sh ; \ 
-    python pcgr.py \
-    --input_vcf examples/tumor_sample.COAD.vcf.gz \
-    --input_cna examples/tumor_sample.COAD.cna.tsv \
-    . \
-    examples \
-    grch37 \
-    examples/pcgr_conf.COAD.toml \
-    tumor_sample.COAD
-    --no-docker
+  - source install_no_docker/load_pcgr.sh
+  # - python pcgr.py \
+  #   --input_vcf examples/tumor_sample.COAD.vcf.gz \
+  #   --input_cna examples/tumor_sample.COAD.cna.tsv \
+  #   . \
+  #   examples \
+  #   grch37 \
+  #   examples/pcgr_conf.COAD.toml \
+  #   tumor_sample.COAD
+  #   --no-docker
 
 
 #notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ install:
   # Installing (the non-docker version)
   - source install_no_docker/install.sh
 
-
 script:
-  - source load_pcgr.sh
+  - source install_no_docker/load_pcgr.sh
   # (Skipping running an actual test because we don't have enough Travis disk space for full data bundles)
   # - python pcgr.py \
   #   --input_vcf examples/tumor_sample.COAD.vcf.gz \

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ before_install:
 
 install:
   # Installing (the non-docker version)
-  - cd install_no_docker ; bash install.sh ; cd ..
+  - source install_no_docker/install.sh
 
 
 script:
-  - source install_no_docker/load_pcgr.sh
+  - source load_pcgr.sh
   # - python pcgr.py \
   #   --input_vcf examples/tumor_sample.COAD.vcf.gz \
   #   --input_cna examples/tumor_sample.COAD.cna.tsv \

--- a/install_no_docker/README.md
+++ b/install_no_docker/README.md
@@ -1,30 +1,27 @@
 ## No-docker install
 
-This is an alternative way to install PCGR that does not require Docker on your machine. Instead of pulling the image, 
-run the following script:
+This is an alternative way to install PCGR that does not require Docker on your machine. Run the following commands:
 
 ```
-cd install_no_docker
-bash install.sh
+# Install dependencies
+bash -x install_no_docker/install.sh
+
+# Install reference data for your genome build
+pip install gdown
+gdown https://drive.google.com/uc?id=1cGBAmAh5t4miIeRrrd0zHsPCFToOr0Lf -O - | tar xvfz - # grch37
+gdown https://drive.google.com/uc?id=12q3rr7xpdBfaefRi0ysFHbH34kehNZOV -O - | tar xvfz - # grch38
 ```
 
-This script installs all dependencies from package repositories like Conda and CRAN. If you don't have conda in your 
-path, it'll download miniconda and create a fresh environment. If you are already in an active environment, it will 
-attempt to install everything into it.
+The first script will install all dependencies from package repositories like Conda and CRAN. If you don't have conda 
+in your path, it'll download miniconda and create a fresh environment. If you are already in an active environment, 
+it will attempt to install everything into it.
 
 This does not guarantee a successful install: due to ongoing updates of the packages in public repositories, you might 
 end up with issues due to version conflics, or unsupported versions for some packages, or missing packages for your 
 system. So try to stick to the dockerized version if possible.
 
-After installing all dependencies, you will still need to download and uncompress data bundles, according to the 
-[README](https://github.com/sigven/pcgr). You can do it from the command line with the gdrive CLI:
-
-```
-cd ..
-git clone https://github.com/circulosmeos/gdown.pl
-gdown.pl/gdown.pl https://drive.google.com/file/d/1cGBAmAh5t4miIeRrrd0zHsPCFToOr0Lf/view pcgr.databundle.grch37.tgz
-gzip -dc pcgr.databundle.grch37.tgz | tar xvf -
-```
+After installing all dependencies, you will need to run download data bundles, either manually following the links in 
+the [README](https://github.com/sigven/pcgr), or using googledrive CLI as shown above.
 
 ### Running
 

--- a/install_no_docker/conda_environment.yml
+++ b/install_no_docker/conda_environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - perl-dbi
   - perl-dbd-mysql
   - perl-bioperl
+  - ensembl-vep>=92
   #
   # PCGR: R packages
   - pandoc<2  # r-rmarkdown 1.6 doesn't support pandoc 2, and a more recent r-rmarkdown is not available on conda

--- a/install_no_docker/conda_environment.yml
+++ b/install_no_docker/conda_environment.yml
@@ -53,6 +53,7 @@ dependencies:
   - r-rcpptoml
   - r-ggplot2
   - r-dt
+  - r-stringi>=1.1.7  # for pcgrr
   - r-htmlwidgets>=1.0  # dependency requirement for DT (by default, 0.9 is getting installed)
   - r-crosstalk
   - r-deconstructsigs

--- a/install_no_docker/install.sh
+++ b/install_no_docker/install.sh
@@ -45,7 +45,7 @@ R -e "library(devtools); options(unzip = '$(which unzip)'); devtools::install_gi
 R -e "library(devtools); devtools::install('${SRC_DIR}/R/pcgrr')"
 
 # Install VEP separately (doesn't work when within the envirnoment file, for some reason):
-conda install -c bioconda -y ensembl-vep
+conda install -c bioconda -y "ensembl-vep==88.9-0"
 # Install VEP plugins:
 vep_install --AUTO p --PLUGINS miRNA --NO_HTSLIB --NO_UPDATE
 

--- a/install_no_docker/install.sh
+++ b/install_no_docker/install.sh
@@ -45,7 +45,7 @@ R -e "library(devtools); options(unzip = '$(which unzip)'); devtools::install_gi
 R -e "library(devtools); devtools::install('${SRC_DIR}/R/pcgrr')"
 
 # Install VEP separately (doesn't work when within the envirnoment file, for some reason):
-conda install -c bioconda -y "ensembl-vep==88.9-0"
+conda install -c bioconda -c conda-forge -c defaults -y "ensembl-vep>=92.4"
 # Install VEP plugins:
 vep_install --AUTO p --PLUGINS miRNA --NO_HTSLIB --NO_UPDATE
 

--- a/install_no_docker/install.sh
+++ b/install_no_docker/install.sh
@@ -7,6 +7,7 @@ set -e
 set -o pipefail
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SKIP_VALIDATOR=$1
 
 # Install conda if needed:
 if [ ! -x "$(command -v conda)" ]; then
@@ -48,9 +49,11 @@ conda install -c bioconda -y ensembl-vep
 # Install VEP plugins:
 vep_install --AUTO p --PLUGINS miRNA --NO_HTSLIB --NO_UPDATE
 
-# Install the EBI vcf validator
-wget https://github.com/EBIvariation/vcf-validator/releases/download/v0.7/vcf_validator -O ${CONDA_PREFIX}/bin/vcf_validator
-chmod +x ${CONDA_PREFIX}/bin/vcf_validator
+if [ -z $SKIP_VALIDATOR ] ; then
+    # Install the EBI vcf validator
+    wget https://github.com/EBIvariation/vcf-validator/releases/download/v0.7/vcf_validator -O ${CONDA_PREFIX}/bin/vcf_validator
+    chmod +x ${CONDA_PREFIX}/bin/vcf_validator
+fi
 
 # Access to src scripts
 chmod +x ${SRC_DIR}/pcgr/*.py

--- a/install_no_docker/install.sh
+++ b/install_no_docker/install.sh
@@ -45,7 +45,7 @@ R -e "library(devtools); options(unzip = '$(which unzip)'); devtools::install_gi
 R -e "library(devtools); devtools::install('${SRC_DIR}/R/pcgrr')"
 
 # Install VEP separately (doesn't work when within the envirnoment file, for some reason):
-conda install -c bioconda -c conda-forge -c defaults -y "ensembl-vep>=92.4"
+#conda install -c bioconda -c conda-forge -c defaults -y "ensembl-vep>=92"
 # Install VEP plugins:
 vep_install --AUTO p --PLUGINS miRNA --NO_HTSLIB --NO_UPDATE
 

--- a/install_no_docker/install.sh
+++ b/install_no_docker/install.sh
@@ -60,7 +60,7 @@ chmod +x ${SRC_DIR}/pcgr/*.py
 chmod +x ${SRC_DIR}/*.R
 
 # Create a loader. Usage: `source load_pcgr.sh`
-cat <<EOT > load_pcgr.sh
+cat <<EOT > ${THIS_DIR}/load_pcgr.sh
 export PATH=${THIS_DIR}/miniconda/bin:\$PATH
 source activate pcgr
 EOT

--- a/install_no_docker/install.sh
+++ b/install_no_docker/install.sh
@@ -44,12 +44,10 @@ R -e "library(devtools); options(unzip = '$(which unzip)'); devtools::install_gi
 # This one is local
 R -e "library(devtools); devtools::install('${SRC_DIR}/R/pcgrr')"
 
-# Install VEP separately (doesn't work when within the envirnoment file, for some reason):
-#conda install -c bioconda -c conda-forge -c defaults -y "ensembl-vep>=92"
 # Install VEP plugins:
 vep_install --AUTO p --PLUGINS miRNA --NO_HTSLIB --NO_UPDATE
 
-if [ -z $SKIP_VALIDATOR ] ; then
+if [ -z ${SKIP_VALIDATOR} ] ; then
     # Install the EBI vcf validator
     wget https://github.com/EBIvariation/vcf-validator/releases/download/v0.6/vcf_validator -O ${CONDA_PREFIX}/bin/vcf_validator
     chmod +x ${CONDA_PREFIX}/bin/vcf_validator

--- a/install_no_docker/install.sh
+++ b/install_no_docker/install.sh
@@ -51,7 +51,7 @@ vep_install --AUTO p --PLUGINS miRNA --NO_HTSLIB --NO_UPDATE
 
 if [ -z $SKIP_VALIDATOR ] ; then
     # Install the EBI vcf validator
-    wget https://github.com/EBIvariation/vcf-validator/releases/download/v0.7/vcf_validator -O ${CONDA_PREFIX}/bin/vcf_validator
+    wget https://github.com/EBIvariation/vcf-validator/releases/download/v0.6/vcf_validator -O ${CONDA_PREFIX}/bin/vcf_validator
     chmod +x ${CONDA_PREFIX}/bin/vcf_validator
 fi
 

--- a/pcgr.py
+++ b/pcgr.py
@@ -490,6 +490,7 @@ def run_pcgr(host_directories, docker_image_version, config_options, sample_id, 
 
       fasta_assembly = os.path.join(vep_dir, "homo_sapiens", str(vep_version) + "_" + str(vep_assembly), "Homo_sapiens." + str(vep_assembly) + ".dna.primary_assembly.fa.gz")
       vep_options = "--vcf --check_ref --flag_pick_allele --force_overwrite --species homo_sapiens --assembly " + str(vep_assembly) + " --offline --fork " + str(config_options['other']['n_vep_forks']) + " --hgvs --dont_skip --failed 1 --af --af_1kg --af_gnomad --variant_class --regulatory --domains --symbol --protein --ccds --uniprot --appris --biotype --canonical --gencode_basic --cache --numbers --total_length --allele_number --no_stats --no_escape --xref_refseq --dir " + vep_dir
+      vep_options += " --cache_version 92"
       if config_options['other']['vep_skip_intergenic'] == 1:
          vep_options = vep_options + " --no_intergenic"
       vep_main_command = docker_command_run1 + "vep --input_file " + str(input_vcf_pcgr_ready) + " --output_file " + str(vep_tmp_vcf) + " " + str(vep_options) + " --fasta " + str(fasta_assembly) + docker_command_run_end


### PR DESCRIPTION
Hi Sigve,

Proposing minor clean-ups around the no-docker installation. 

1. Pinned some dependencies versions:
    - Pin EBI-validator to 0.6 (as per #43)
    - Pin `r-stringi>=1.1.7` (earlier versions have some issues)
    - Pin VEP to >=92 and moved it into the conda environment file.

    I think later I will actually freeze the whole environment and this way pin versions for all dependencies, so we will have a guaranteed stable no-docker installation.

2. I also cleaned up Travis CI file, and make it only test the installation (because there is no disk space on their machine to download the data bundle). We can now turn on automated testing at https://travis-ci.org/ for the pcgr repository.  UPD: moved the logic into the Appveyor file, so no need to enable Travis :)

3. And also (perhaps) to address the first problem in #43, I added cleaner instructions into `install_no_docker/README.md` to make sure users see that they have to download the data bundles after running the script.

Vlad