### PR TITLE
Correct MSI minimal calls check

### DIFF
--- a/src/R/pcgrr/R/msi.R
+++ b/src/R/pcgrr/R/msi.R
@@ -237,7 +237,7 @@ generate_report_data_msi <- function(sample_calls, pcgr_data, pcgr_version, samp
   #msi_sample_calls <- sample_calls %>% dplyr::filter(stringr::str_detect(CONSEQUENCE,"^(frameshift_|missense_|splice_|synonymous_|stop_|start_lost|inframe_)"))
   msi_sample_calls <- sample_calls %>% dplyr::filter(CODING_STATUS == "coding")
   rlogging::message(paste0("n = ",nrow(msi_sample_calls)," coding variants used for MSI prediction"))
-  if(nrow(msi_sample_calls) > 30){
+  if(nrow(msi_sample_calls) >= 30){
     pcg_report_msi[['prediction']] <- pcgrr::predict_msi_status(msi_sample_calls, simpleRepeats_gr = pcgr_data$simpleRepeats_gr, windowMasker_gr = pcgr_data$windowMasker_gr, msi_prediction_model = pcgr_data$msi_model$model, msi_prediction_dataset = pcgr_data$msi_model$tcga_dataset, target_size_mb = pcgr_config$mutational_burden$target_size_mb, bsg = genome_seq, genome_assembly = genome_assembly, sample_name = sample_name)
     pcg_report_msi[['eval']] <- TRUE
   }


### PR DESCRIPTION
A minor correction to avoid a misleading error message. The error says `n < 30`, so the check should be `n >= 30`.

<img width="681" alt="screen shot 2018-11-21 at 20 38 45" src="https://user-images.githubusercontent.com/1575412/48832535-7a41a080-edcd-11e8-8849-3c1cf8141483.png">
