### PR TITLE
Update Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,24 @@
 image: ubuntu
 
 install:
-  # Installing (the non-docker version)
-  - bash -x install_no_docker/install.sh
+  - wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH=$HOME/miniconda/bin:$PATH
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a  # Useful for debugging any issues with conda
+  - export PACKAGE_NAME=pcgr
+  # Setting up channels and install dependencies
+  - conda config --add channels pcgr --add channels bioconda --add channels conda-forge
+  - conda install -q python=$TRAVIS_PYTHON_VERSION pip requests conda-build jinja2 anaconda-client
+  # Building package
+  - conda build install_no_docker/conda_pkg/${PACKAGE_NAME}
+  - conda build install_no_docker/conda_pkg/${PACKAGE_NAME}_dockerized
+  - conda install --use-local ${PACKAGE_NAME}
 
 test_script:
-  - source install_no_docker/load_pcgr.sh
+  - pcgr.py --version
+  - python -c "import pcgr"
 
 build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 install:
   - export PACKAGE_NAME=pcgr
   # Setting up channels and install dependencies
-  - conda config --add channels defaults --add channels pcgr --add channels bioconda --add channels conda-forge
+  - conda config --add channels pcgr --add channels bioconda --add channels conda-forge
   - conda install -q python=$TRAVIS_PYTHON_VERSION pip requests conda-build jinja2 anaconda-client
   # Building package
   - conda build install_no_docker/conda_pkg/${PACKAGE_NAME}

--- a/install_no_docker/README.md
+++ b/install_no_docker/README.md
@@ -33,8 +33,8 @@ conda install --use-local $CHANNELS pcgr
 Finally you can download reference data bundle for your genome build and you are all set:
 
 ```
-gdown https://drive.google.com/uc?id=1Ny0diC7MumyaOLutN8-1EoAJ7jOOK9Gn -O - | tar xvzf - # grch37
-gdown https://drive.google.com/uc?id=1VtYtURsPoELR_eYqZTBVguK3tZo3aBVm -O - | tar xvzf - # grch38
+gdown https://drive.google.com/uc?id=1OL5C994HDaeadASz7KzMhPoXfdSiyhNy -O - | tar xvzf - # grch37
+gdown https://drive.google.com/uc?id=1CZNc87E0K5AK2RDSNU57FqLp0H1skpUh -O - | tar xvzf - # grch38
 ```
 
 There is a chance you'll encounter errors during the installation. Due to ongoing updates of the packages in public repositories, some packages might end up conflicting with each other or missing for your system. So try to stick to the dockerized version of PCGR whenever possible.


### PR DESCRIPTION
Updating Appveyor file to make it work, now it does the same as Travis: installs and checks condarized PCGR, except that it doesn't deploy to anaconda.

On second thought, should we rather disable Appveyor for good given that we have Travis?