### PR TITLE
Travis: run full test, test dockerized

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,24 +1,43 @@
 image: ubuntu
 
+services:
+  - docker
+
 install:
+  # Pulling the image
+  - sudo service docker start
+  - docker pull sigven/pcgr:dev
+  # Installing wrapper script dependencies
   - wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH=$HOME/miniconda/bin:$PATH
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a  # Useful for debugging any issues with conda
-  - export PACKAGE_NAME=pcgr
-  # Setting up channels and install dependencies
-  - conda config --add channels pcgr --add channels bioconda --add channels conda-forge
-  - conda install -q python=$TRAVIS_PYTHON_VERSION pip requests conda-build jinja2 anaconda-client
-  # Building package
-  - conda build install_no_docker/conda_pkg/${PACKAGE_NAME}
-  - conda build install_no_docker/conda_pkg/${PACKAGE_NAME}_dockerized
-  - conda install --use-local ${PACKAGE_NAME}
+  - conda install -y -c conda-forge -c pcgr toml gdown
+  # Downloading datab bundle - commenting out because getting "not enough disk space"
+  #  - gdown https://drive.google.com/uc?id=1OL5C994HDaeadASz7KzMhPoXfdSiyhNy -O - | tar xzf - # grch37
 
 test_script:
-  - pcgr.py --version
-  - python -c "import pcgr"
+  - python pcgr.py --version
+  # Full test - commenting out because getting "not enough disk space" at gdown step
+  #  - python pcgr.py --input_vcf examples/tumor_sample.COAD.vcf.gz --input_cna examples/tumor_sample.COAD.cna.tsv . ./examples grch37 examples/pcgr_conf.COAD.toml tumor_sample.COAD
 
 build: off
+
+# TODO: build and push docker from here - see https://stefanscherer.github.io/setup-windows-docker-ci-appveyor/
+#environment:
+#  DOCKER_USER:
+#    secure: xxxxxxx
+#  DOCKER_PASS:
+#    secure: yyyyyyy
+#
+#install:
+#  - docker version
+#
+#build_script:
+#  - docker build -t me/myfavoriteapp .
+#
+#test_script:
+#  - docker run me/myfavoriteapp
+#
+#deploy_script:
+#  - docker login -u="$env:DOCKER_USER" -p="$env:DOCKER_PASS"
+#  - docker push me/myfavoriteapp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ language: python
 python:
   - "3.6"  # required, otherwise conda will try to clash with py2 packages
 
-## Download data bundles. (skipping this because of lack of disk space on Travis)
-#before_install:
-#  - cd ..
-#  - git clone https://github.com/circulosmeos/gdown.pl
-#  - gdown.pl/gdown.pl https://drive.google.com/file/d/1cGBAmAh5t4miIeRrrd0zHsPCFToOr0Lf/view pcgr.databundle.grch37.tgz
-#  - gzip -dc pcgr.databundle.grch37.tgz | tar xvf -
+services:
+  - docker
 
 before_install:
   # Get and install anaconda (https://conda.io/docs/travis.html)
@@ -22,28 +18,38 @@ before_install:
   - conda info -a  # Useful for debugging any issues with conda
 
 install:
+  # Set up conda
   - export PACKAGE_NAME=pcgr
   # Setting up channels and install dependencies
   - conda config --add channels pcgr --add channels bioconda --add channels conda-forge
   - conda install -q python=$TRAVIS_PYTHON_VERSION pip requests conda-build jinja2 anaconda-client
-  # Building package
+  # Building packages
   - conda build install_no_docker/conda_pkg/${PACKAGE_NAME}
   - conda build install_no_docker/conda_pkg/${PACKAGE_NAME}_dockerized
-  - conda install --use-local ${PACKAGE_NAME}
+  #
+  # Dockerized installation:
+  - docker pull sigven/pcgr:dev
+  - conda install --use-local ${PACKAGE_NAME}_dockerized
+  # Download the data bundle (usable for both version)
+  - gdown https://drive.google.com/uc?id=1OL5C994HDaeadASz7KzMhPoXfdSiyhNy -O - | tar xzf - # grch37
 
 script:
+  # Dockerized installation:
   - pcgr.py --version
   - python -c "import pcgr"
-  # (Skipping running an actual test because we don't have enough Travis disk space for full data bundles)
-  # - python pcgr.py \
-  #   --input_vcf examples/tumor_sample.COAD.vcf.gz \
-  #   --input_cna examples/tumor_sample.COAD.cna.tsv \
-  #   . \
-  #   examples \
-  #   grch37 \
-  #   examples/pcgr_conf.COAD.toml \
-  #   tumor_sample.COAD
-  #   --no-docker
+  - pcgr.py
+    --input_vcf examples/tumor_sample.COAD.vcf.gz
+    --input_cna examples/tumor_sample.COAD.cna.tsv
+    . ./examples grch37 examples/pcgr_conf.COAD.toml tumor_sample.COAD
+  #
+  # Condarized installation:
+  - conda install --use-local ${PACKAGE_NAME}
+  - pcgr.py --version
+  - python -c "import pcgr"
+  - pcgr.py
+    --input_vcf examples/tumor_sample.BRCA.vcf.gz
+    --input_cna examples/tumor_sample.BRCA.cna.tsv
+    . ./examples grch37 examples/pcgr_conf.BRCA.toml tumor_sample.BRCA --no-docker
 
 deploy:
   # Deploy to Anaconda.org


### PR DESCRIPTION
Sigve,

Travis can now run full tests, both for dockerized and condarized versions.

To summarize, that's what Travis is doing now on each commit:
- Pulls dev docker image,
- Downloads the GRCh37 data bundle,
- Runs the COAD example using the standard dockerized installation,
- Builds the conda package,
- Runs the BRCA example using the no-docker installation.

Also on each tag it uploads the conda image to anaconda repository. Ideally it should also build and push the docker image, but we are running out of Travis run time allowance.

And we should disable AppVeyor now - it doesn't even download the data bundle because of the disk space.

The verdict: merge this PR and disable AppVeyor.

Vlad