### PR TITLE
Fix parsing biomarkers and avoid VEP fails with chrM

### DIFF
--- a/pcgr.py
+++ b/pcgr.py
@@ -647,7 +647,7 @@ def run_pcgr(host_directories, docker_image_version, config_options, sample_id, 
       #pick_order = "canonical,appris,tsl,biotype,ccds,rank,length" 
       #pick_order = "biotype,canonical,appris,tsl,ccds,rank,length"
       fasta_assembly = os.path.join(vep_dir, "homo_sapiens", str(vep_version) + "_" + str(vep_assembly), "Homo_sapiens." + str(vep_assembly) + ".dna.primary_assembly.fa.gz")
-      vep_flags = "--hgvs --failed 1 --af --af_1kg --af_gnomad --variant_class --domains --symbol --protein --ccds --uniprot --appris --biotype --canonical --gencode_basic --cache --numbers --total_length --allele_number --no_stats --no_escape --xref_refseq"
+      vep_flags = "--hgvs --af --af_1kg --af_gnomad --variant_class --domains --symbol --protein --ccds --uniprot --appris --biotype --canonical --gencode_basic --cache --numbers --total_length --allele_number --no_stats --no_escape --xref_refseq"
       vep_options = "--vcf --check_ref --dont_skip --flag_pick_allele --pick_order " + str(config_options['other']['vep_pick_order']) + " --force_overwrite --species homo_sapiens --assembly " + str(vep_assembly) + " --offline --fork " + str(config_options['other']['n_vep_forks']) + " " + str(vep_flags)  + " --dir " + vep_dir
       vep_options += " --cache_version " + str(vep_version)
       if config_options['other']['vep_skip_intergenic'] == 1:

--- a/src/R/pcgrr/R/biomarkers.R
+++ b/src/R/pcgrr/R/biomarkers.R
@@ -71,7 +71,7 @@ get_clinical_associations_snv_indel <- function(sample_calls, pcgr_data, pcgr_co
         eitems <- dplyr::inner_join(civic_calls,civic_biomarkers,by=c("CIVIC_ID" = "evidence_id")) %>% dplyr::distinct()
         names(eitems) <- toupper(names(eitems))
         eitems <- eitems %>% dplyr::select(-c(EITEM_CONSEQUENCE,MAPPING_CATEGORY,EITEM_CODON,EITEM_EXON))
-        clinical_evidence_items <- rbind(clinical_evidence_items, eitems)
+        clinical_evidence_items <- rbind.fill(clinical_evidence_items, eitems)
       }
       sample_calls_cbmdb <- sample_calls %>% dplyr::filter(is.na(CIVIC_ID) & !is.na(CBMDB_ID))
       if(nrow(sample_calls_cbmdb) > 0){
@@ -82,7 +82,7 @@ get_clinical_associations_snv_indel <- function(sample_calls, pcgr_data, pcgr_co
         eitems <- dplyr::inner_join(cbmdb_calls,cbmdb_biomarkers,by=c("CBMDB_ID" = "evidence_id")) %>% dplyr::distinct()
         names(eitems) <- toupper(names(eitems))
         eitems <- eitems %>% dplyr::select(-c(EITEM_CONSEQUENCE,MAPPING_CATEGORY,EITEM_CODON,EITEM_EXON))
-        clinical_evidence_items <- rbind(clinical_evidence_items, eitems)
+        clinical_evidence_items <- rbind.fill(clinical_evidence_items, eitems)
       }
     }
     else{
@@ -257,7 +257,7 @@ names(civic_cna_biomarkers) <- toupper(names(civic_cna_biomarkers))
           biomarker_hits <- biomarker_hits_civic
         }
         if(nrow(biomarker_hits) > 0){
-          cna_biomarkers <- rbind(cna_biomarkers,biomarker_hits)
+          cna_biomarkers <- rbind.fill(cna_biomarkers,biomarker_hits)
         }
       }
     }


### PR DESCRIPTION
A couple of minor fixes. One is an extension of https://github.com/sigven/pcgr/pull/82/commits/4a769f417c332b157f852676fc68809a528413d1. Another one is a hg38 fix for the case when there are variants in mitochondria. PCGR strips the "chr" prefixes making chrM->M, however Ensembl expects MT as in the reference file. For now the fix will just ignore mitochondria, but might wanna do it properly in the future.