### PR TITLE
[R] Export functions and use .data (PART 1)

### DIFF
--- a/src/R/pcgrr/R/acmg.R
+++ b/src/R/pcgrr/R/acmg.R
@@ -3,7 +3,7 @@
 #' @param pcg_report_snv_indel report object for snv/indels
 #'
 #' @return pcg_report_data data frame with all report elements
-#'
+#' @export
 
 assign_tier1_tier2_acmg <- function(pcg_report_snv_indel) {
 
@@ -30,7 +30,7 @@ assign_tier1_tier2_acmg <- function(pcg_report_snv_indel) {
     if (nrow(eitems_specific_ttype[[etype]][["A_B"]]) > 0) {
       vars <-
         dplyr::select(eitems_specific_ttype[[etype]][["A_B"]],
-                      GENOMIC_CHANGE) %>%
+                      .data$GENOMIC_CHANGE) %>%
         dplyr::distinct()
       unique_variants_tier1 <-
         rbind(unique_variants_tier1, vars) %>%
@@ -72,7 +72,7 @@ assign_tier1_tier2_acmg <- function(pcg_report_snv_indel) {
           unique_variants_tier2 <- unique_variants_tier2 %>%
             dplyr::bind_rows(
               dplyr::select(eitems_other_ttype[[etype]][["A_B"]],
-                            GENOMIC_CHANGE)) %>%
+                            .data$GENOMIC_CHANGE)) %>%
             dplyr::distinct()
         }
       }
@@ -93,7 +93,7 @@ assign_tier1_tier2_acmg <- function(pcg_report_snv_indel) {
         unique_variants_tier2 <- unique_variants_tier2 %>%
           dplyr::bind_rows(
             dplyr::select(eitems_specific_ttype[[etype]][["C_D_E"]],
-                          GENOMIC_CHANGE)) %>%
+                          .data$GENOMIC_CHANGE)) %>%
           dplyr::distinct()
       }
     }
@@ -152,7 +152,7 @@ assign_tier1_tier2_acmg <- function(pcg_report_snv_indel) {
 #'
 #' @return pcg_report_data data frame with all report elements
 #'
-
+#' @export
 
 assign_tier1_tier2_acmg_cna <- function(pcg_report_cna) {
 
@@ -179,7 +179,7 @@ assign_tier1_tier2_acmg_cna <- function(pcg_report_cna) {
                                   only_colnames = F, quiet = T)
 
       vars <- dplyr::select(eitems_specific_ttype[[etype]][["A_B"]],
-                            SYMBOL, SEGMENT, CNA_TYPE) %>%
+                            .data$SYMBOL, .data$SEGMENT, .data$CNA_TYPE) %>%
         dplyr::distinct()
       unique_variants_tier1 <- rbind(unique_variants_tier1, vars) %>%
         dplyr::distinct()
@@ -225,7 +225,7 @@ assign_tier1_tier2_acmg_cna <- function(pcg_report_cna) {
           unique_variants_tier2 <- unique_variants_tier2 %>%
             dplyr::bind_rows(
               dplyr::select(eitems_other_ttype[[etype]][["A_B"]],
-                            SYMBOL, SEGMENT, CNA_TYPE)) %>%
+                            .data$SYMBOL, .data$SEGMENT, .data$CNA_TYPE)) %>%
             dplyr::distinct()
         }
       }
@@ -252,7 +252,7 @@ assign_tier1_tier2_acmg_cna <- function(pcg_report_cna) {
         unique_variants_tier2 <- unique_variants_tier2 %>%
           dplyr::bind_rows(
             dplyr::select(eitems_specific_ttype[[etype]][["C_D_E"]],
-                          SYMBOL, SEGMENT, CNA_TYPE)) %>%
+                          .data$SYMBOL, .data$SEGMENT, .data$CNA_TYPE)) %>%
           dplyr::distinct()
       }
     }

--- a/src/R/pcgrr/R/biomarkers.R
+++ b/src/R/pcgrr/R/biomarkers.R
@@ -6,6 +6,7 @@
 #' @param eitems data frame with clinical evidence items
 #'
 #' @return list
+#' @export
 
 get_clin_assocs_snv_indel <- function(sample_calls,
                                       annotation_tags = NULL,
@@ -142,6 +143,7 @@ get_clin_assocs_snv_indel <- function(sample_calls,
 #' @param eitems Data frame with clinical evidence items
 #'
 #' @return list
+#' @export
 #'
 get_clin_assocs_cna <- function(onco_ts_sets,
                                 annotation_tags = NULL,
@@ -206,6 +208,7 @@ get_clin_assocs_cna <- function(onco_ts_sets,
 
 }
 
+#' @export
 load_eitems <- function(eitems_raw = NULL,
                         ontology = NULL,
                         alteration_type = "MUT",
@@ -270,7 +273,7 @@ load_eitems <- function(eitems_raw = NULL,
 
 
   if (tumor_type_specificity == "any") {
-    pcgrr:::log4r_info(
+    log4r_info(
       paste0(
         "Loading ", alteration_type, " biomarkers for precision oncology",
         "- any tumortype"))
@@ -299,7 +302,7 @@ load_eitems <- function(eitems_raw = NULL,
         eitems,
         ontology = ontology,
         primary_site = tumor_type)
-    pcgrr:::log4r_info(
+    log4r_info(
       paste0("Loading ", alteration_type,
              " biomarkers for precision oncology - ",
              tumor_type))
@@ -309,6 +312,7 @@ load_eitems <- function(eitems_raw = NULL,
 
 }
 
+#' @export
 load_all_eitems <- function(eitems_raw = NULL,
                             alteration_type = "MUT",
                             origin = "Somatic") {
@@ -356,10 +360,10 @@ load_all_eitems <- function(eitems_raw = NULL,
     if(alteration_type == "CNA") {
       selected_eitems[[db]] <-
         eitems_raw[[db]] %>%
-          dplyr::filter(ALTERATION_TYPE == alteration_type &
-                          !is.na(EITEM_CONSEQUENCE) &
-                          stringr::str_detect(VARIANT_ORIGIN, origin)) %>%
-          dplyr::rename(CNA_TYPE = EITEM_CONSEQUENCE) %>%
+          dplyr::filter(.data$ALTERATION_TYPE == alteration_type &
+                          !is.na(.data$EITEM_CONSEQUENCE) &
+                          stringr::str_detect(.data$VARIANT_ORIGIN, origin)) %>%
+          dplyr::rename(CNA_TYPE = .data$EITEM_CONSEQUENCE) %>%
           pcgrr::remove_cols_from_df(
             cnames =
               c("VARIANT_NAME",
@@ -374,8 +378,8 @@ load_all_eitems <- function(eitems_raw = NULL,
     if (alteration_type == "MUT" | alteration_type == "MUT_LOF") {
       selected_eitems[[db]] <-
         eitems_raw[[db]] %>%
-        dplyr::filter(ALTERATION_TYPE == alteration_type &
-                        stringr::str_detect(VARIANT_ORIGIN, origin)) %>%
+        dplyr::filter(.data$ALTERATION_TYPE == alteration_type &
+                        stringr::str_detect(.data$VARIANT_ORIGIN, origin)) %>%
         pcgrr::remove_cols_from_df(
           cnames =
             c("VARIANT_NAME",
@@ -397,6 +401,7 @@ load_all_eitems <- function(eitems_raw = NULL,
 }
 
 
+#' @export
 match_eitems_to_var <- function(sample_calls,
                                db = "civic",
                                colset = NULL,
@@ -455,7 +460,7 @@ match_eitems_to_var <- function(sample_calls,
       dplyr::select(
         dplyr::one_of(colset)) %>%
       dplyr::rename(EVIDENCE_ID = !!rlang::sym(evidence_identifiers[1])) %>%
-      dplyr::mutate(EVIDENCE_ID = as.character(EVIDENCE_ID)) %>%
+      dplyr::mutate(EVIDENCE_ID = as.character(.data$EVIDENCE_ID)) %>%
       pcgrr::remove_cols_from_df(cnames = evidence_identifiers[2])
     )
   }
@@ -475,8 +480,7 @@ match_eitems_to_var <- function(sample_calls,
 
 }
 
-##
-##
+#' @export
 qc_var_eitems <- function(var_eitems = NULL,
                           marker_type = "codon") {
 
@@ -503,13 +507,13 @@ qc_var_eitems <- function(var_eitems = NULL,
     if (nrow(var_eitems[!is.na(var_eitems$EITEM_CODON) &
                     var_eitems$BIOMARKER_MAPPING == "codon", ]) > 0) {
       filtered_var_eitems <- var_eitems %>%
-        dplyr::filter(!is.na(EITEM_CODON) & BIOMARKER_MAPPING == "codon") %>%
-        dplyr::filter(EITEM_CODON <= AMINO_ACID_END &
-                        EITEM_CODON >= AMINO_ACID_START &
-                        (!is.na(EITEM_CONSEQUENCE) &
-                           startsWith(CONSEQUENCE, EITEM_CONSEQUENCE) |
-                           is.na(EITEM_CONSEQUENCE)) &
-                        CODING_STATUS == "coding")
+        dplyr::filter(!is.na(.data$EITEM_CODON) & .data$BIOMARKER_MAPPING == "codon") %>%
+        dplyr::filter(.data$EITEM_CODON <= .data$AMINO_ACID_END &
+                        .data$EITEM_CODON >= .data$AMINO_ACID_START &
+                        (!is.na(.data$EITEM_CONSEQUENCE) &
+                           startsWith(.data$CONSEQUENCE, .data$EITEM_CONSEQUENCE) |
+                           is.na(.data$EITEM_CONSEQUENCE)) &
+                        .data$CODING_STATUS == "coding")
 
     }
   }
@@ -518,22 +522,22 @@ qc_var_eitems <- function(var_eitems = NULL,
     if (nrow(var_eitems[!is.na(var_eitems$EITEM_EXON) &
                     var_eitems$BIOMARKER_MAPPING == "exon", ]) > 0) {
       filtered_var_eitems <- var_eitems %>%
-        dplyr::filter(!is.na(EITEM_EXON) & BIOMARKER_MAPPING == "exon") %>%
-        dplyr::filter(EXON == EITEM_EXON &
-                        (!is.na(EITEM_CONSEQUENCE) &
-                          startsWith(CONSEQUENCE, EITEM_CONSEQUENCE) |
-                         is.na(EITEM_CONSEQUENCE)) & CODING_STATUS == "coding")
+        dplyr::filter(!is.na(.data$EITEM_EXON) & .data$BIOMARKER_MAPPING == "exon") %>%
+        dplyr::filter(.data$EXON == .data$EITEM_EXON &
+                        (!is.na(.data$EITEM_CONSEQUENCE) &
+                          startsWith(.data$CONSEQUENCE, .data$EITEM_CONSEQUENCE) |
+                         is.na(.data$EITEM_CONSEQUENCE)) & .data$CODING_STATUS == "coding")
     }
   }
 
   if (marker_type == "gene") {
     if (nrow(var_eitems[var_eitems$BIOMARKER_MAPPING == "gene", ]) > 0) {
       filtered_var_eitems <- var_eitems %>%
-        dplyr::filter(BIOMARKER_MAPPING == "gene" &
-                        CODING_STATUS == "coding") %>%
-        dplyr::filter((!is.na(EITEM_CONSEQUENCE) &
-                         startsWith(CONSEQUENCE, EITEM_CONSEQUENCE) |
-                         is.na(EITEM_CONSEQUENCE)) & CODING_STATUS == "coding")
+        dplyr::filter(.data$BIOMARKER_MAPPING == "gene" &
+                        .data$CODING_STATUS == "coding") %>%
+        dplyr::filter((!is.na(.data$EITEM_CONSEQUENCE) &
+                         startsWith(.data$CONSEQUENCE, .data$EITEM_CONSEQUENCE) |
+                         is.na(.data$EITEM_CONSEQUENCE)) & .data$CODING_STATUS == "coding")
 
     }
   }
@@ -544,11 +548,11 @@ qc_var_eitems <- function(var_eitems = NULL,
        "ALTERATION_TYPE" %in% colnames(filtered_var_eitems)){
 
       filtered_var_eitems <- filtered_var_eitems %>%
-        dplyr::filter((LOSS_OF_FUNCTION == T &
-                         ALTERATION_TYPE == "MUT_LOF") |
-                        is.na(LOSS_OF_FUNCTION) |
-                        (LOSS_OF_FUNCTION == F &
-                           ALTERATION_TYPE != "MUT_LOF"))
+        dplyr::filter((.data$LOSS_OF_FUNCTION == T &
+                         .data$ALTERATION_TYPE == "MUT_LOF") |
+                        is.na(.data$LOSS_OF_FUNCTION) |
+                        (.data$LOSS_OF_FUNCTION == F &
+                           .data$ALTERATION_TYPE != "MUT_LOF"))
     }
   }
 
@@ -561,6 +565,7 @@ qc_var_eitems <- function(var_eitems = NULL,
 
 }
 
+#' @export
 filter_eitems_by_site <- function(eitems = NULL,
                                   ontology = NULL,
                                   primary_site = "") {
@@ -603,10 +608,10 @@ filter_eitems_by_site <- function(eitems = NULL,
   tumor_phenotypes_site <-
     dplyr::semi_join(
       dplyr::select(ontology,
-                    primary_site, do_id, cui, cui_name),
+                    .data$primary_site, .data$do_id, .data$cui, .data$cui_name),
       data.frame("primary_site" = primary_site, stringsAsFactors = F),
       by = c("primary_site" = "primary_site")) %>%
-    dplyr::filter(!is.na(do_id)) %>%
+    dplyr::filter(!is.na(.data$do_id)) %>%
     dplyr::distinct()
 
   eitems <- eitems %>%
@@ -616,6 +621,7 @@ filter_eitems_by_site <- function(eitems = NULL,
   return(eitems)
 }
 
+#' @export
 structure_var_eitems <- function(var_eitems,
                               annotation_tags,
                               alteration_type = "MUT") {
@@ -637,27 +643,27 @@ structure_var_eitems <- function(var_eitems,
     for (type in c("prognostic", "diagnostic", "predictive")) {
       clin_eitems_list[[type]][["any"]] <- var_eitems %>%
         dplyr::select(dplyr::one_of(tags_display)) %>%
-        dplyr::filter(EVIDENCE_TYPE == stringr::str_to_title(type)) %>%
-        dplyr::arrange(EVIDENCE_LEVEL, desc(RATING))
+        dplyr::filter(.data$EVIDENCE_TYPE == stringr::str_to_title(type)) %>%
+        dplyr::arrange(.data$EVIDENCE_LEVEL, dplyr::desc(.data$RATING))
       if (nrow(clin_eitems_list[[type]][["any"]]) > 0) {
         clin_eitems_list[[type]][["A_B"]] <-
           clin_eitems_list[[type]][["any"]] %>%
-          dplyr::filter(stringr::str_detect(EVIDENCE_LEVEL, "^(A|B|B1|B2):"))
+          dplyr::filter(stringr::str_detect(.data$EVIDENCE_LEVEL, "^(A|B|B1|B2):"))
 
         if (NROW(clin_eitems_list[[type]][["A_B"]]) > 0) {
           clin_eitems_list[[type]][["A_B"]] <-
             clin_eitems_list[[type]][["A_B"]] %>%
-            dplyr::arrange(EVIDENCE_LEVEL, desc(RATING))
+            dplyr::arrange(.data$EVIDENCE_LEVEL, dplyr::desc(.data$RATING))
         }
 
         clin_eitems_list[[type]][["C_D_E"]] <-
           clin_eitems_list[[type]][["any"]] %>%
-          dplyr::filter(stringr::str_detect(EVIDENCE_LEVEL, "^(C|D|E):"))
+          dplyr::filter(stringr::str_detect(.data$EVIDENCE_LEVEL, "^(C|D|E):"))
 
         if (NROW(clin_eitems_list[[type]][["C_D_E"]]) > 0) {
           clin_eitems_list[[type]][["C_D_E"]] <-
             clin_eitems_list[[type]][["C_D_E"]] %>%
-            dplyr::arrange(EVIDENCE_LEVEL, desc(RATING))
+            dplyr::arrange(.data$EVIDENCE_LEVEL, dplyr::desc(.data$RATING))
         }
       }
     }
@@ -667,6 +673,7 @@ structure_var_eitems <- function(var_eitems,
 
 }
 
+#' @export
 deduplicate_eitems <- function(var_eitems = NULL,
                                target_type = "exact",
                                target_other = c("codon","exon","gene")){
@@ -718,7 +725,7 @@ deduplicate_eitems <- function(var_eitems = NULL,
                                     only_colnames = F, quiet = T)
         var_eitems[[m]] <- var_eitems[[m]] %>%
           dplyr::anti_join(
-            dplyr::select(var_eitems[[target_type]], GENOMIC_CHANGE),
+            dplyr::select(var_eitems[[target_type]], .data$GENOMIC_CHANGE),
             by = c("GENOMIC_CHANGE"))
       }
     }
@@ -726,6 +733,7 @@ deduplicate_eitems <- function(var_eitems = NULL,
   return(var_eitems)
 }
 
+#' @export
 log_var_eitem_stats <- function(var_eitems = NULL,
                                target_type = "exact"){
 
@@ -742,7 +750,7 @@ log_var_eitem_stats <- function(var_eitems = NULL,
                                          " or 'exon' or 'gene'")))
 
 
-  pcgrr:::log4r_info(
+  log4r_info(
     paste0("Found n = ",
            NROW(var_eitems[[target_type]]),
            " other clinical evidence item(s) at the ", target_type,
@@ -756,7 +764,7 @@ log_var_eitem_stats <- function(var_eitems = NULL,
       var_eitems[[target_type]],
       c("SYMBOL","CONSEQUENCE","PROTEIN_CHANGE"),
       only_colnames = F, quiet = T)
-    pcgrr:::log4r_info(
+    log4r_info(
       paste0("Variants: ",
              paste(unique(paste(var_eitems[[target_type]]$SYMBOL,
                                 var_eitems[[target_type]]$CONSEQUENCE,

--- a/src/R/pcgrr/R/clinicaltrials.R
+++ b/src/R/pcgrr/R/clinicaltrials.R
@@ -5,7 +5,7 @@
 #' @param sample_name sample name
 #'
 #' @return pcg_report_trials data frame with all report elements
-#'
+#' @export
 
 generate_report_data_trials <- function(pcgr_data, config, sample_name) {
 
@@ -24,45 +24,45 @@ generate_report_data_trials <- function(pcgr_data, config, sample_name) {
 
   pcg_report_trials[["trials"]] <-
     pcgr_data[["clinicaltrials"]][["trials"]] %>%
-    dplyr::filter(primary_site ==
+    dplyr::filter(.data$primary_site ==
                     config[["t_props"]][["tumor_type"]])
 
   if (nrow(pcg_report_trials[["trials"]]) > 0) {
 
     pcg_report_trials[["trials"]] <- pcg_report_trials[["trials"]] %>%
-      dplyr::select(nct_id, title, overall_status,
-                    cui_link, intervention_link,
-                    phase, start_date,
-                    primary_completion_date, cui_name,
-                    intervention,
-                    intervention_target,
-                    biomarker_context,
-                    chromosome_abnormality,
-                    clinical_context,
-                    world_region,
-                    metastases, gender,
-                    minimum_age, maximum_age, phase,
-                    n_primary_cancer_sites,
-                    study_design_primary_purpose) %>%
-      dplyr::rename(condition_raw = cui_name,
-                    condition = cui_link,
-                    intervention2 = intervention_link,
-                    intervention_raw = intervention,
-                    biomarker_index = biomarker_context,
-                    keyword = clinical_context,
-                    chrom_abnormalities = chromosome_abnormality,
-                    metastases_index = metastases) %>%
-      dplyr::rename(intervention = intervention2) %>%
+      dplyr::select(.data$nct_id, .data$title, .data$overall_status,
+                    .data$cui_link, .data$intervention_link,
+                    .data$phase, .data$start_date,
+                    .data$primary_completion_date, .data$cui_name,
+                    .data$intervention,
+                    .data$intervention_target,
+                    .data$biomarker_context,
+                    .data$chromosome_abnormality,
+                    .data$clinical_context,
+                    .data$world_region,
+                    .data$metastases, .data$gender,
+                    .data$minimum_age, .data$maximum_age, .data$phase,
+                    .data$n_primary_cancer_sites,
+                    .data$study_design_primary_purpose) %>%
+      dplyr::rename(condition_raw = .data$cui_name,
+                    condition = .data$cui_link,
+                    intervention2 = .data$intervention_link,
+                    intervention_raw = .data$intervention,
+                    biomarker_index = .data$biomarker_context,
+                    keyword = .data$clinical_context,
+                    chrom_abnormalities = .data$chromosome_abnormality,
+                    metastases_index = .data$metastases) %>%
+      dplyr::rename(intervention = .data$intervention2) %>%
       magrittr::set_colnames(toupper(names(.))) %>%
-      dplyr::arrange(N_PRIMARY_CANCER_SITES,
-                     OVERALL_STATUS, desc(START_DATE),
-                     desc(nchar(BIOMARKER_INDEX),
-                          STUDY_DESIGN_PRIMARY_PURPOSE)) %>%
-      dplyr::select(-c(N_PRIMARY_CANCER_SITES, STUDY_DESIGN_PRIMARY_PURPOSE))
+      dplyr::arrange(.data$N_PRIMARY_CANCER_SITES,
+                     .data$OVERALL_STATUS, dplyr::desc(.data$START_DATE),
+                     dplyr::desc(nchar(.data$BIOMARKER_INDEX),
+                          .data$STUDY_DESIGN_PRIMARY_PURPOSE)) %>%
+      dplyr::select(-c(.data$N_PRIMARY_CANCER_SITES, .data$STUDY_DESIGN_PRIMARY_PURPOSE))
 
     if (nrow(pcg_report_trials[["trials"]]) > 2000) {
       pcg_report_trials[["trials"]] <-
-        head(pcg_report_trials[["trials"]], 2000)
+        utils::head(pcg_report_trials[["trials"]], 2000)
     }
 
   }else{

--- a/src/R/pcgrr/R/cna.R
+++ b/src/R/pcgrr/R/cna.R
@@ -6,6 +6,7 @@
 #' @param genome_assembly genome assembly (grch37/grch38)
 #' @param bsg BSgenome object
 #'
+#' @export
 get_valid_chromosome_segments <-
   function(cna_segments_df,
            genome_assembly = "grch37",
@@ -25,26 +26,26 @@ get_valid_chromosome_segments <-
     quiet = T)
 
   chromosome_lengths <-
-    data.frame(chromosome = head(names(seqlengths(bsg)), 24),
-               chrom_length = head(seqlengths(bsg), 24),
+    data.frame(chromosome = utils::head(names(GenomeInfoDb::seqlengths(bsg)), 24),
+               chrom_length = utils::head(GenomeInfoDb::seqlengths(bsg), 24),
                stringsAsFactors = F, row.names = NULL)
   cna_segments_df <- as.data.frame(
     cna_segments_df %>%
       dplyr::left_join(chromosome_lengths, by = c("chromosome")) %>%
       dplyr::rowwise() %>%
-      dplyr::mutate(segment_error = segment_end > chrom_length)
+      dplyr::mutate(segment_error = .data$segment_end > .data$chrom_length)
     )
-  if (nrow(dplyr::filter(cna_segments_df, segment_error == T)) > 0) {
-    n_removed <- nrow(dplyr::filter(cna_segments_df, segment_error == T))
-    pcgrr:::log4r_warn(paste0(
+  if (nrow(dplyr::filter(cna_segments_df, .data$segment_error == T)) > 0) {
+    n_removed <- nrow(dplyr::filter(cna_segments_df, .data$segment_error == T))
+    log4r_warn(paste0(
       "Skipping ", n_removed,
       " copy number segments that span beyond chromosomal lengths for ",
       genome_assembly,
       " (make sure chromosomal segments are consistent with assembly)"))
   }
   cna_segments_df <- cna_segments_df %>%
-    dplyr::filter(segment_error == F) %>%
-    dplyr::select(-c(segment_error, chrom_length))
+    dplyr::filter(.data$segment_error == F) %>%
+    dplyr::select(-c(.data$segment_error, .data$chrom_length))
 
   return(cna_segments_df)
 }
@@ -54,6 +55,7 @@ get_valid_chromosome_segments <-
 #' @param cna_df genomic ranges object with copy number aberrations
 #' @param pcgr_data pcgr data bundle object
 #'
+#' @export
 get_cna_cytoband <- function(cna_df, pcgr_data = NULL) {
 
   cna_gr <-
@@ -85,43 +87,43 @@ get_cna_cytoband <- function(cna_df, pcgr_data = NULL) {
 
   cyto_stats <- as.data.frame(
     cyto_df %>%
-      dplyr::group_by(SEGMENT_ID, segment_length) %>%
+      dplyr::group_by(.data$SEGMENT_ID, .data$segment_length) %>%
       dplyr::summarise(
-        CYTOBAND = paste(name, collapse = ", "),
-        chromosome_arm = paste(unique(arm), collapse = ","),
-        focalCNAthresholds = paste(unique(focalCNAthreshold), collapse = ","),
+        CYTOBAND = paste(.data$name, collapse = ", "),
+        chromosome_arm = paste(unique(.data$arm), collapse = ","),
+        focalCNAthresholds = paste(unique(.data$focalCNAthreshold), collapse = ","),
         .groups = "drop") %>%
       dplyr::ungroup() %>%
       dplyr::mutate(
         focalCNAthresholds =
-          dplyr::if_else(stringr::str_detect(focalCNAthresholds, ","),
+          dplyr::if_else(stringr::str_detect(.data$focalCNAthresholds, ","),
                          as.character(NA),
-                         as.character(focalCNAthresholds))) %>%
+                         as.character(.data$focalCNAthresholds))) %>%
       dplyr::mutate(
         focalCNAthresholds =
-          dplyr::if_else(!is.na(focalCNAthresholds),
-                         as.numeric(focalCNAthresholds),
+          dplyr::if_else(!is.na(.data$focalCNAthresholds),
+                         as.numeric(.data$focalCNAthresholds),
                          as.numeric(NA))) %>%
       dplyr::rowwise() %>%
-      dplyr::mutate(broad_cnv_event = segment_length > focalCNAthresholds) %>%
+      dplyr::mutate(broad_cnv_event = .data$segment_length > .data$focalCNAthresholds) %>%
       dplyr::mutate(EVENT_TYPE = "broad") %>%
       dplyr::mutate(
         EVENT_TYPE =
           dplyr::if_else(
-            !is.na(broad_cnv_event) & broad_cnv_event == F,
-            "focal", EVENT_TYPE)) %>%
+            !is.na(.data$broad_cnv_event) & .data$broad_cnv_event == F,
+            "focal", .data$EVENT_TYPE)) %>%
       dplyr::mutate(EVENT_TYPE = dplyr::if_else(
-        is.na(broad_cnv_event),
-        as.character("broad"), EVENT_TYPE)) %>%
+        is.na(.data$broad_cnv_event),
+        as.character("broad"), .data$EVENT_TYPE)) %>%
       dplyr::mutate(
         CYTOBAND =
-          stringr::str_replace(CYTOBAND, ", (\\S+, ) {0,}", " - ")) %>%
-      tidyr::separate(SEGMENT_ID,
+          stringr::str_replace(.data$CYTOBAND, ", (\\S+, ) {0,}", " - ")) %>%
+      tidyr::separate(.data$SEGMENT_ID,
                       sep = ":",
                       into = c("chrom", "start_stop"),
                       remove = F) %>%
-      dplyr::mutate(CYTOBAND = paste0(chrom, ":", CYTOBAND)) %>%
-      dplyr::select(SEGMENT_ID, CYTOBAND, EVENT_TYPE)
+      dplyr::mutate(CYTOBAND = paste0(.data$chrom, ":", .data$CYTOBAND)) %>%
+      dplyr::select(.data$SEGMENT_ID, .data$CYTOBAND, .data$EVENT_TYPE)
 
   )
   cna_df <- cna_df %>%
@@ -131,6 +133,7 @@ get_cna_cytoband <- function(cna_df, pcgr_data = NULL) {
 
 }
 
+#' @export
 get_oncogene_tsgene_target_sets <- function(
   cna_df,
   transcript_overlap_pct = 100,
@@ -154,20 +157,20 @@ get_oncogene_tsgene_target_sets <- function(
   onco_ts_sets <- list()
   onco_ts_sets[["oncogene_gain"]] <- data.frame()
   onco_ts_sets[["oncogene_gain"]] <-
-    dplyr::filter(cna_df, ONCOGENE == T & TUMOR_SUPPRESSOR == F &
-                    MEAN_TRANSCRIPT_CNA_OVERLAP >= transcript_overlap_pct &
-                    LOG_R >= log_r_gain)
+    dplyr::filter(cna_df, .data$ONCOGENE == T & .data$TUMOR_SUPPRESSOR == F &
+                    .data$MEAN_TRANSCRIPT_CNA_OVERLAP >= transcript_overlap_pct &
+                    .data$LOG_R >= log_r_gain)
   onco_ts_sets[["tsgene_loss"]] <- data.frame()
   onco_ts_sets[["tsgene_loss"]] <-
-    dplyr::filter(cna_df, TUMOR_SUPPRESSOR == T &
-                    MEAN_TRANSCRIPT_CNA_OVERLAP >= transcript_overlap_pct  &
-                    LOG_R <= log_r_homdel)
+    dplyr::filter(cna_df, .data$TUMOR_SUPPRESSOR == T &
+                    .data$MEAN_TRANSCRIPT_CNA_OVERLAP >= transcript_overlap_pct  &
+                    .data$LOG_R <= log_r_homdel)
 
   onco_ts_sets[["other_target"]] <- data.frame()
   onco_ts_sets[["other_target"]] <-
-    dplyr::filter(cna_df, TUMOR_SUPPRESSOR == F & ONCOGENE == F &
-                    MEAN_TRANSCRIPT_CNA_OVERLAP >= transcript_overlap_pct  &
-                    LOG_R >= log_r_gain)
+    dplyr::filter(cna_df, .data$TUMOR_SUPPRESSOR == F & .data$ONCOGENE == F &
+                    .data$MEAN_TRANSCRIPT_CNA_OVERLAP >= transcript_overlap_pct  &
+                    .data$LOG_R >= log_r_gain)
 
   drug_target_site <-
     pcgrr::targeted_drugs_pr_ttype(
@@ -178,21 +181,21 @@ get_oncogene_tsgene_target_sets <- function(
   if (nrow(onco_ts_sets[["other_target"]]) > 0) {
     onco_ts_sets[["other_target"]] <- onco_ts_sets[["other_target"]] %>%
       dplyr::left_join(drug_target_site, by = "SYMBOL") %>%
-      dplyr::filter(!is.na(DRUGS_ON_LABEL) | !is.na(DRUGS_OFF_LABEL)) %>%
-      dplyr::select(-c(TUMOR_SUPPRESSOR, ONCOGENE,
-                       TUMOR_SUPPRESSOR_EVIDENCE, ONCOGENE_EVIDENCE)) %>%
+      dplyr::filter(!is.na(.data$DRUGS_ON_LABEL) | !is.na(.data$DRUGS_OFF_LABEL)) %>%
+      dplyr::select(-c(.data$TUMOR_SUPPRESSOR, .data$ONCOGENE,
+                       .data$TUMOR_SUPPRESSOR_EVIDENCE, .data$ONCOGENE_EVIDENCE)) %>%
       dplyr::distinct() %>%
-      dplyr::select(CHROMOSOME, SYMBOL, GENE_NAME, SEGMENT, EVENT_TYPE,
-                    DRUGS_ON_LABEL, DRUGS_OFF_LABEL,
-                    SEGMENT_LENGTH_MB, LOG_R, SEGMENT_ID,
-                    DRUGS_ON_LABEL_INDICATIONS,
-                    DRUGS_OFF_LABEL_INDICATIONS, MEAN_TRANSCRIPT_CNA_OVERLAP,
-                    KEGG_PATHWAY, TRANSCRIPTS) %>%
+      dplyr::select(.data$CHROMOSOME, .data$SYMBOL, .data$GENE_NAME, .data$SEGMENT, .data$EVENT_TYPE,
+                    .data$DRUGS_ON_LABEL, .data$DRUGS_OFF_LABEL,
+                    .data$SEGMENT_LENGTH_MB, .data$LOG_R, .data$SEGMENT_ID,
+                    .data$DRUGS_ON_LABEL_INDICATIONS,
+                    .data$DRUGS_OFF_LABEL_INDICATIONS, .data$MEAN_TRANSCRIPT_CNA_OVERLAP,
+                    .data$KEGG_PATHWAY, .data$TRANSCRIPTS) %>%
       dplyr::mutate(MEAN_TRANSCRIPT_CNA_OVERLAP =
-                      paste0(MEAN_TRANSCRIPT_CNA_OVERLAP, "%")) %>%
+                      paste0(.data$MEAN_TRANSCRIPT_CNA_OVERLAP, "%")) %>%
       dplyr::mutate(CNA_TYPE = "gain")
 
-    pcgrr:::log4r_info(
+    log4r_info(
       paste0("Detected ", nrow(onco_ts_sets[["other_target"]]),
              " drug targets to amplification (log(2) ratio >= ",
              log_r_gain, "): ",
@@ -204,37 +207,37 @@ get_oncogene_tsgene_target_sets <- function(
   for (t in c("oncogene_gain", "tsgene_loss")) {
     if (nrow(onco_ts_sets[[t]]) > 0) {
       onco_ts_sets[[t]] <- onco_ts_sets[[t]] %>%
-        dplyr::select(-c(TUMOR_SUPPRESSOR, ONCOGENE)) %>%
+        dplyr::select(-c(.data$TUMOR_SUPPRESSOR, .data$ONCOGENE)) %>%
         dplyr::distinct() %>%
-        dplyr::select(CHROMOSOME, SYMBOL, GENE_NAME,
-                      SEGMENT, LOG_R, EVENT_TYPE,
-                      SEGMENT_LENGTH_MB,
-                      MEAN_TRANSCRIPT_CNA_OVERLAP,
-                      KEGG_PATHWAY,
-                      TRANSCRIPTS, SEGMENT_ID) %>%
+        dplyr::select(.data$CHROMOSOME, .data$SYMBOL, .data$GENE_NAME,
+                      .data$SEGMENT, .data$LOG_R, .data$EVENT_TYPE,
+                      .data$SEGMENT_LENGTH_MB,
+                      .data$MEAN_TRANSCRIPT_CNA_OVERLAP,
+                      .data$KEGG_PATHWAY,
+                      .data$TRANSCRIPTS, .data$SEGMENT_ID) %>%
         dplyr::mutate(
           MEAN_TRANSCRIPT_CNA_OVERLAP = paste0(
-            MEAN_TRANSCRIPT_CNA_OVERLAP, "%")) %>%
+            .data$MEAN_TRANSCRIPT_CNA_OVERLAP, "%")) %>%
         dplyr::mutate(CNA_TYPE =
                         dplyr::if_else(t == "oncogene_gain" |
                                          t == "other_target",
                                        "gain", "loss"))
       if (t == "oncogene_gain") {
-        pcgrr:::log4r_info(
+        log4r_info(
           paste0("Detected ", nrow(onco_ts_sets[[t]]),
                  " proto-oncogene(s) subject to amplification (log(2) ratio >= ",
                  log_r_gain, "): ",
                  paste0(unique(onco_ts_sets[[t]]$SYMBOL), collapse = ", ")))
         onco_ts_sets[[t]] <- onco_ts_sets[[t]] %>%
           dplyr::left_join(drug_target_site, by = "SYMBOL") %>%
-          dplyr::select(CHROMOSOME, SYMBOL,
-                        GENE_NAME, SEGMENT,
-                        LOG_R, EVENT_TYPE,
-                        DRUGS_ON_LABEL,
-                        DRUGS_OFF_LABEL, dplyr::everything()) %>%
-          dplyr::arrange(DRUGS_ON_LABEL, DRUGS_OFF_LABEL)
+          dplyr::select(.data$CHROMOSOME, .data$SYMBOL,
+                        .data$GENE_NAME, .data$SEGMENT,
+                        .data$LOG_R, .data$EVENT_TYPE,
+                        .data$DRUGS_ON_LABEL,
+                        .data$DRUGS_OFF_LABEL, dplyr::everything()) %>%
+          dplyr::arrange(.data$DRUGS_ON_LABEL, .data$DRUGS_OFF_LABEL)
       }else{
-          pcgrr:::log4r_info(
+          log4r_info(
             paste0("Detected ", nrow(onco_ts_sets[[t]]),
                    " tumor suppressor gene(s) subject to ",
                    "homozygous deletions (log(2) ratio <= ",
@@ -243,15 +246,15 @@ get_oncogene_tsgene_target_sets <- function(
       }
     }else{
       if (t == "tsgene_loss") {
-        pcgrr:::log4r_info(paste0("Detected 0 tumor suppressor genes subject to",
+        log4r_info(paste0("Detected 0 tumor suppressor genes subject to",
                           " homozygous deletion (log(2) ratio <= ",
                           log_r_homdel))
       }else{
         if (t == "other_target") {
-          pcgrr:::log4r_info(paste0("Detected 0 other drug targets subject to ",
+          log4r_info(paste0("Detected 0 other drug targets subject to ",
                             "amplification (log(2) ratio >= ", log_r_gain))
         }else{
-          pcgrr:::log4r_info(paste0("Detected 0 proto-oncogenes subject to ",
+          log4r_info(paste0("Detected 0 proto-oncogenes subject to ",
                             "amplification (log(2) ratio >= ", log_r_gain))
         }
       }
@@ -262,6 +265,7 @@ get_oncogene_tsgene_target_sets <- function(
 
 }
 
+#' @export
 get_cna_overlapping_transcripts <- function(cna_df, pcgr_data) {
 
   cna_gr <-
@@ -295,13 +299,13 @@ get_cna_overlapping_transcripts <- function(cna_df, pcgr_data) {
         dplyr::mutate(
           transcript_end = end(ranges)) %>%
         dplyr::mutate(
-          chrom = as.character(seqnames(ranges))) %>%
+          chrom = as.character(GenomeInfoDb::seqnames(ranges))) %>%
         dplyr::rowwise() %>%
         dplyr::mutate(
           transcript_overlap_percent =
-            round(as.numeric((min(transcript_end, segment_end) -
-                                max(segment_start, transcript_start)) /
-                               (transcript_end - transcript_start)) * 100,
+            round(as.numeric((min(.data$transcript_end, .data$segment_end) -
+                                max(.data$segment_start, .data$transcript_start)) /
+                               (.data$transcript_end - .data$transcript_start)) * 100,
                   digits = 2))
     ) %>%
     pcgrr::sort_chromosomal_segments(chromosome_column = "chrom",

--- a/src/R/pcgrr/R/germline.R
+++ b/src/R/pcgrr/R/germline.R
@@ -1,4 +1,4 @@
-
+#' @export
 max_af_gnomad <- function(sample_calls){
   invisible(
     assertthat::assert_that(is.data.frame(sample_calls),
@@ -29,6 +29,7 @@ max_af_gnomad <- function(sample_calls){
   return(sample_calls)
 }
 
+#' @export
 max_af_onekg <- function(sample_calls){
   invisible(
     assertthat::assert_that(is.data.frame(sample_calls),
@@ -58,6 +59,7 @@ max_af_onekg <- function(sample_calls){
   return(sample_calls)
 }
 
+#' @export
 clinvar_germline_status <- function(sample_calls){
 
   invisible(
@@ -73,15 +75,16 @@ clinvar_germline_status <- function(sample_calls){
       dplyr::mutate(
         STATUS_CLINVAR_GERMLINE =
           dplyr::if_else(
-            !is.na(CLINVAR_MSID) &
-              stringr::str_detect(CLINVAR_VARIANT_ORIGIN, "germline") &
-              !stringr::str_detect(CLINVAR_VARIANT_ORIGIN, "somatic"),
+            !is.na(.data$CLINVAR_MSID) &
+              stringr::str_detect(.data$CLINVAR_VARIANT_ORIGIN, "germline") &
+              !stringr::str_detect(.data$CLINVAR_VARIANT_ORIGIN, "somatic"),
             TRUE, FALSE))
   }
   return(sample_calls)
 }
 
 
+#' @export
 dbsnp_germline_status <- function(sample_calls){
 
   invisible(
@@ -98,23 +101,24 @@ dbsnp_germline_status <- function(sample_calls){
     sample_calls <- sample_calls %>%
       dplyr::mutate(
         STATUS_DBSNP_GERMLINE =
-          dplyr::if_else(!is.na(DBSNPRSID), TRUE, FALSE)) %>%
+          dplyr::if_else(!is.na(.data$DBSNPRSID), TRUE, FALSE)) %>%
       dplyr::mutate(
         STATUS_DBSNP_GERMLINE =
-          dplyr::if_else(STATUS_DBSNP_GERMLINE == T &
-                           !is.na(DOCM_PMID),
-                         FALSE, STATUS_DBSNP_GERMLINE)) %>%
+          dplyr::if_else(.data$STATUS_DBSNP_GERMLINE == T &
+                           !is.na(.data$DOCM_PMID),
+                         FALSE, .data$STATUS_DBSNP_GERMLINE)) %>%
       dplyr::mutate(
         STATUS_DBSNP_GERMLINE =
           dplyr::if_else(
-            STATUS_DBSNP_GERMLINE == T &
-              !is.na(CLINVAR_MSID) &
-              stringr::str_detect(CLINVAR_VARIANT_ORIGIN, "somatic"),
-            FALSE, STATUS_DBSNP_GERMLINE))
+            .data$STATUS_DBSNP_GERMLINE == T &
+              !is.na(.data$CLINVAR_MSID) &
+              stringr::str_detect(.data$CLINVAR_VARIANT_ORIGIN, "somatic"),
+            FALSE, .data$STATUS_DBSNP_GERMLINE))
   }
   return(sample_calls)
 }
 
+#' @export
 tcga_somatic_status <- function(sample_calls){
 
   invisible(
@@ -128,12 +132,13 @@ tcga_somatic_status <- function(sample_calls){
     sample_calls <- sample_calls %>%
       dplyr::mutate(
         STATUS_TCGA_SOMATIC =
-          dplyr::if_else(!is.na(TCGA_PANCANCER_COUNT), TRUE, FALSE))
+          dplyr::if_else(!is.na(.data$TCGA_PANCANCER_COUNT), TRUE, FALSE))
   }
   return(sample_calls)
 
 }
 
+#' @export
 cosmic_somatic_status <- function(sample_calls){
 
   invisible(
@@ -147,12 +152,13 @@ cosmic_somatic_status <- function(sample_calls){
     sample_calls <- sample_calls %>%
       dplyr::mutate(
         STATUS_COSMIC =
-          dplyr::if_else(!is.na(COSMIC_MUTATION_ID), TRUE, FALSE))
+          dplyr::if_else(!is.na(.data$COSMIC_MUTATION_ID), TRUE, FALSE))
   }
   return(sample_calls)
 
 }
 
+#' @export
 hom_af_status <- function(sample_calls){
 
 
@@ -167,12 +173,13 @@ hom_af_status <- function(sample_calls){
     sample_calls <- sample_calls %>%
       dplyr::mutate(
         STATUS_LIKELY_GERMLINE_HOMOZYGOUS =
-          dplyr::if_else(!is.na(AF_TUMOR) & AF_TUMOR == 1,
+          dplyr::if_else(!is.na(.data$AF_TUMOR) & .data$AF_TUMOR == 1,
                          TRUE, FALSE))
   }
   return(sample_calls)
 }
 
+#' @export
 pon_status <- function(sample_calls){
 
   invisible(
@@ -186,12 +193,13 @@ pon_status <- function(sample_calls){
     sample_calls <- sample_calls %>%
       dplyr::mutate(
         STATUS_PON =
-          dplyr::if_else(PANEL_OF_NORMALS == TRUE,
+          dplyr::if_else(.data$PANEL_OF_NORMALS == TRUE,
                          TRUE, FALSE))
   }
   return(sample_calls)
 }
 
+#' @export
 het_af_germline_status <- function(sample_calls){
 
   invisible(
@@ -211,12 +219,12 @@ het_af_germline_status <- function(sample_calls){
     sample_calls <- sample_calls %>%
       dplyr::mutate(
         STATUS_LIKELY_GERMLINE_HETEROZYGOUS =
-          dplyr::if_else(!is.na(MAX_AF_GNOMAD) &
-                           STATUS_DBSNP_GERMLINE == TRUE &
-                           !is.na(AF_TUMOR) &
-                           AF_TUMOR >= 0.40 & AF_TUMOR <= 0.60 &
-                           STATUS_TCGA_SOMATIC == FALSE &
-                           STATUS_COSMIC == FALSE, TRUE, FALSE))
+          dplyr::if_else(!is.na(.data$MAX_AF_GNOMAD) &
+                           .data$STATUS_DBSNP_GERMLINE == TRUE &
+                           !is.na(.data$AF_TUMOR) &
+                           .data$AF_TUMOR >= 0.40 & .data$AF_TUMOR <= 0.60 &
+                           .data$STATUS_TCGA_SOMATIC == FALSE &
+                           .data$STATUS_COSMIC == FALSE, TRUE, FALSE))
   }
   return(sample_calls)
 }
@@ -231,6 +239,7 @@ het_af_germline_status <- function(sample_calls){
 #'
 #' @return sample_calls
 #'
+#' @export
 
 assign_somatic_classification <- function(sample_calls, config) {
 
@@ -257,39 +266,39 @@ assign_somatic_classification <- function(sample_calls, config) {
   sample_calls <- sample_calls %>%
     dplyr::mutate(
       SOMATIC_CLASSIFICATION =
-        dplyr::if_else(STATUS_POPFREQ_1KG_ABOVE_TOLERATED == TRUE,
-                       "GERMLINE_1KG", SOMATIC_CLASSIFICATION)) %>%
+        dplyr::if_else(.data$STATUS_POPFREQ_1KG_ABOVE_TOLERATED == TRUE,
+                       "GERMLINE_1KG", .data$SOMATIC_CLASSIFICATION)) %>%
     dplyr::mutate(
       SOMATIC_CLASSIFICATION =
-        dplyr::if_else(STATUS_POPFREQ_GNOMAD_ABOVE_TOLERATED == TRUE &
-                         SOMATIC_CLASSIFICATION == "SOMATIC",
-                       "GERMLINE_GNOMAD", SOMATIC_CLASSIFICATION)) %>%
+        dplyr::if_else(.data$STATUS_POPFREQ_GNOMAD_ABOVE_TOLERATED == TRUE &
+                         .data$SOMATIC_CLASSIFICATION == "SOMATIC",
+                       "GERMLINE_GNOMAD", .data$SOMATIC_CLASSIFICATION)) %>%
     dplyr::mutate(
       SOMATIC_CLASSIFICATION =
-        dplyr::if_else(STATUS_CLINVAR_GERMLINE == TRUE &
-                         SOMATIC_CLASSIFICATION == "SOMATIC",
-                       "GERMLINE_CLINVAR", SOMATIC_CLASSIFICATION)) %>%
+        dplyr::if_else(.data$STATUS_CLINVAR_GERMLINE == TRUE &
+                         .data$SOMATIC_CLASSIFICATION == "SOMATIC",
+                       "GERMLINE_CLINVAR", .data$SOMATIC_CLASSIFICATION)) %>%
     dplyr::mutate(
       SOMATIC_CLASSIFICATION =
-        dplyr::if_else(STATUS_PON == TRUE &
+        dplyr::if_else(.data$STATUS_PON == TRUE &
                          config[["tumor_only"]][["exclude_pon"]] == TRUE &
-                         SOMATIC_CLASSIFICATION == "SOMATIC",
-                       "GERMLINE_PON", SOMATIC_CLASSIFICATION)) %>%
+                         .data$SOMATIC_CLASSIFICATION == "SOMATIC",
+                       "GERMLINE_PON", .data$SOMATIC_CLASSIFICATION)) %>%
 
     dplyr::mutate(
       SOMATIC_CLASSIFICATION =
         dplyr::if_else(
-          STATUS_LIKELY_GERMLINE_HOMOZYGOUS == TRUE &
+          .data$STATUS_LIKELY_GERMLINE_HOMOZYGOUS == TRUE &
             config[["tumor_only"]][["exclude_likely_hom_germline"]] == TRUE &
-            SOMATIC_CLASSIFICATION == "SOMATIC",
-          "GERMLINE_HOMOZYGOUS", SOMATIC_CLASSIFICATION)) %>%
+            .data$SOMATIC_CLASSIFICATION == "SOMATIC",
+          "GERMLINE_HOMOZYGOUS", .data$SOMATIC_CLASSIFICATION)) %>%
     dplyr::mutate(
       SOMATIC_CLASSIFICATION =
         dplyr::if_else(
-          STATUS_LIKELY_GERMLINE_HETEROZYGOUS == TRUE &
+          .data$STATUS_LIKELY_GERMLINE_HETEROZYGOUS == TRUE &
             config[["tumor_only"]][["exclude_likely_het_germline"]] == TRUE &
-            SOMATIC_CLASSIFICATION == "SOMATIC",
-          "GERMLINE_HETEROZYGOUS", SOMATIC_CLASSIFICATION))
+            .data$SOMATIC_CLASSIFICATION == "SOMATIC",
+          "GERMLINE_HETEROZYGOUS", .data$SOMATIC_CLASSIFICATION))
 
   ## set variants found in DBSNP as germline if this option is set to TRUE
   if (config[["tumor_only"]][["exclude_dbsnp_nonsomatic"]] == TRUE) {
@@ -297,11 +306,11 @@ assign_somatic_classification <- function(sample_calls, config) {
     sample_calls <- sample_calls %>%
       dplyr::mutate(
         SOMATIC_CLASSIFICATION =
-          dplyr::if_else(STATUS_DBSNP_GERMLINE == TRUE &
-                           STATUS_TCGA_SOMATIC == FALSE &
-                           STATUS_COSMIC == FALSE &
-                           SOMATIC_CLASSIFICATION == "SOMATIC",
-                         "GERMLINE_DBSNP", SOMATIC_CLASSIFICATION))
+          dplyr::if_else(.data$STATUS_DBSNP_GERMLINE == TRUE &
+                           .data$STATUS_TCGA_SOMATIC == FALSE &
+                           .data$STATUS_COSMIC == FALSE &
+                           .data$SOMATIC_CLASSIFICATION == "SOMATIC",
+                         "GERMLINE_DBSNP", .data$SOMATIC_CLASSIFICATION))
 
   }
 
@@ -316,6 +325,7 @@ assign_somatic_classification <- function(sample_calls, config) {
 #'
 #' @return sample_calls
 #'
+#' @export
 
 assign_somatic_germline_evidence <- function(sample_calls, config) {
 
@@ -486,6 +496,7 @@ assign_somatic_germline_evidence <- function(sample_calls, config) {
 #'
 #' @return sample_calls
 #'
+#' @export
 assign_germline_popfreq_status <- function(sample_calls,
                                            pop = "EUR",
                                            dbquery = "1KG",
@@ -543,6 +554,7 @@ assign_germline_popfreq_status <- function(sample_calls,
 #'
 #' @return pop_tag_info
 #'
+#' @export
 get_population_tag <- function(population_code, db = "1KG", subset = NA) {
   pop_tag_info <-
     list("vcf_tag" = paste0(toupper(population_code), "_AF_", db),
@@ -640,16 +652,16 @@ get_population_tag <- function(population_code, db = "1KG", subset = NA) {
 
   if (db == "1KG") {
     pop_entry <- dplyr::filter(pop_descriptions_1KG,
-                               code == population_code)
+                               .data$code == population_code)
     pop_tag_info[["pop_description"]] <- pop_entry$pop_description
   }
   if (db == "GNOMAD") {
     pop_entry <- dplyr::filter(pop_descriptions_gnomad,
-                               code == population_code)
+                               .data$code == population_code)
     pop_tag_info[["pop_description"]] <- pop_entry$pop_description
     if (subset == "non_cancer") {
       pop_entry <- dplyr::filter(pop_descriptions_gnomad_non_cancer,
-                                 code == population_code)
+                                 .data$code == population_code)
       pop_tag_info[["pop_description"]] <- pop_entry$pop_description
     }
 
@@ -666,6 +678,7 @@ get_population_tag <- function(population_code, db = "1KG", subset = NA) {
 #'
 #' @return upset data
 #'
+#' @export
 make_upset_plot_data <- function(calls, config) {
 
   columns <- c()
@@ -687,9 +700,9 @@ make_upset_plot_data <- function(calls, config) {
              "STATUS_POPFREQ_GNOMAD_ABOVE_TOLERATED",
              "STATUS_CLINVAR_GERMLINE"),
     only_colnames = F, quiet = T)
-  df <- dplyr::select(calls, VAR_ID, STATUS_POPFREQ_1KG_ABOVE_TOLERATED,
-                      STATUS_POPFREQ_GNOMAD_ABOVE_TOLERATED,
-                      STATUS_CLINVAR_GERMLINE)
+  df <- dplyr::select(calls, .data$VAR_ID, .data$STATUS_POPFREQ_1KG_ABOVE_TOLERATED,
+                      .data$STATUS_POPFREQ_GNOMAD_ABOVE_TOLERATED,
+                      .data$STATUS_CLINVAR_GERMLINE)
   for (c in columns) {
     if (c %in% colnames(calls)) {
       df[, c] <- calls[, c]
@@ -701,24 +714,25 @@ make_upset_plot_data <- function(calls, config) {
       df[, v] <- as.integer(df[, v])
     }
   }
-  df <- dplyr::rename(df, gnomAD = STATUS_POPFREQ_GNOMAD_ABOVE_TOLERATED,
-                      OneKGP = STATUS_POPFREQ_1KG_ABOVE_TOLERATED,
-                      ClinVar = STATUS_CLINVAR_GERMLINE)
+  df <- dplyr::rename(df, gnomAD = .data$STATUS_POPFREQ_GNOMAD_ABOVE_TOLERATED,
+                      OneKGP = .data$STATUS_POPFREQ_1KG_ABOVE_TOLERATED,
+                      ClinVar = .data$STATUS_CLINVAR_GERMLINE)
   if ("STATUS_PON" %in% colnames(df)) {
-    df <- dplyr::rename(df, Panel_Of_Normals = STATUS_PON)
+    df <- dplyr::rename(df, Panel_Of_Normals = .data$STATUS_PON)
   }
   if ("STATUS_LIKELY_GERMLINE_HOMOZYGOUS" %in% colnames(df)) {
-    df <- dplyr::rename(df, HomAF = STATUS_LIKELY_GERMLINE_HOMOZYGOUS)
+    df <- dplyr::rename(df, HomAF = .data$STATUS_LIKELY_GERMLINE_HOMOZYGOUS)
   }
   if ("STATUS_LIKELY_GERMLINE_HETEROZYGOUS" %in% colnames(df)) {
-    df <- dplyr::rename(df, HetAF = STATUS_LIKELY_GERMLINE_HETEROZYGOUS)
+    df <- dplyr::rename(df, HetAF = .data$STATUS_LIKELY_GERMLINE_HETEROZYGOUS)
   }
   if ("STATUS_DBSNP_GERMLINE" %in% colnames(df)) {
-    df <- dplyr::rename(df, dbSNP = STATUS_DBSNP_GERMLINE)
+    df <- dplyr::rename(df, dbSNP = .data$STATUS_DBSNP_GERMLINE)
   }
   return(df)
 
 }
+
 #' Function that makes an upset calls for germline-filtered variants
 #' classification procedure
 #'
@@ -726,6 +740,7 @@ make_upset_plot_data <- function(calls, config) {
 #'
 #' @return p
 #'
+#' @export
 upset_plot_tumor_only <- function(upset_data) {
 
   isets <- c()

--- a/src/R/pcgrr/R/kataegis.R
+++ b/src/R/pcgrr/R/kataegis.R
@@ -10,13 +10,13 @@
 #'
 #' @return kataegis_df data frame with potential kataegis events
 #'
-#'
+#' @export
 kataegis_detect <- function(data, sample_id = "sample_id",
                             build = "grch37", min.mut = 6,
                             max.dis = 1000,
                             chr = "chr", pos = "pos",
                             txdb = NULL) {
-  pcgrr:::log4r_info(paste0("Detecting possible kataegis events (clusters of C>T ",
+  log4r_info(paste0("Detecting possible kataegis events (clusters of C>T ",
                     "(APOBEC enzyme family) and C>T/G ",
                     "(TLS DNA polymerase) mutations"))
   assertable::assert_colnames(
@@ -76,7 +76,7 @@ kataegis_detect <- function(data, sample_id = "sample_id",
       Cmutnum <- 0
     }
   }
-  kataegis_df <- data.frame(na.omit(katPoint))
+  kataegis_df <- data.frame(stats::na.omit(katPoint))
   names(kataegis_df) <- c("sample_id", "chrom", "start",
                           "end", "chrom.arm", "length", "number.mut",
                           "weight.C>X")
@@ -98,13 +98,13 @@ kataegis_detect <- function(data, sample_id = "sample_id",
         }
       }
     }
-    kataegis_df <- kataegis_df %>% dplyr::arrange(desc(confidence))
+    kataegis_df <- kataegis_df %>% dplyr::arrange(dplyr::desc(.data$confidence))
 
     if (!is.null(txdb)) {
       gr <-
         GenomicRanges::GRanges(
-          seqnames = Rle(kataegis_df$chrom),
-          ranges = IRanges(start = as.numeric(as.character(kataegis_df$start)),
+          seqnames = S4Vectors::Rle(kataegis_df$chrom),
+          ranges = IRanges::IRanges(start = as.numeric(as.character(kataegis_df$start)),
                            end = as.numeric(as.character(kataegis_df$end))))
       peakAnno <- annotatePeak(gr, tssRegion = c(-3000, 3000),
                                TxDb = txdb, annoDb = "org.Hs.eg.db")
@@ -114,7 +114,7 @@ kataegis_detect <- function(data, sample_id = "sample_id",
       kataegis_df$geneID <- peakAnno@anno$geneId
     }
   }
-  pcgrr:::log4r_info(paste(dim(kataegis_df)[1],
+  log4r_info(paste(dim(kataegis_df)[1],
                           "potential kataegis events identified",
                 sep = " "))
   return(kataegis_df)
@@ -131,8 +131,7 @@ kataegis_detect <- function(data, sample_id = "sample_id",
 #' @param build genome build (grch37 or hg38)
 #' @param k size of neighbouring sequence context
 #'
-#'
-
+#' @export
 kataegis_input <- function(variant_set, chr = "chr",
                            pos = "pos", ref = "ref",
                          alt = "alt", build = NULL) {
@@ -161,10 +160,10 @@ kataegis_input <- function(variant_set, chr = "chr",
   context_size <- 10
   if (nrow(mut_data) > 100) {
     bsg <- BSgenome.Hsapiens.UCSC.hg19
-    chr.lens <- as.integer(head(GenomeInfoDb::seqlengths(bsg), 24))
+    chr.lens <- as.integer(utils::head(GenomeInfoDb::seqlengths(bsg), 24))
     if (build == "grch38") {
       bsg <- BSgenome.Hsapiens.UCSC.hg38
-      chr.lens <- as.integer(head(GenomeInfoDb::seqlengths(bsg), 24))
+      chr.lens <- as.integer(utils::head(GenomeInfoDb::seqlengths(bsg), 24))
     }
     mut_data$build <- build
     ref_base <-  Biostrings::DNAStringSet(mut_data$ref)
@@ -206,6 +205,7 @@ kataegis_input <- function(variant_set, chr = "chr",
 #' @param sample_name name of tumor sample
 #' @param build genome assembly (grch37/grch38)
 #'
+#' @export
 generate_report_data_kataegis <- function(variant_set,
                                           sample_name = "SampleX",
                                           build = "grch37") {
@@ -215,8 +215,8 @@ generate_report_data_kataegis <- function(variant_set,
     return(pcg_report_kataegis)
   }
 
-  pcgrr:::log4r_info("------")
-  pcgrr:::log4r_info(
+  log4r_info("------")
+  log4r_info(
     paste0("Kataegis detection from genomic distribution of SNVs"))
 
 
@@ -240,7 +240,7 @@ generate_report_data_kataegis <- function(variant_set,
   }
   if (chr_prefix == F) {
     variant_set <- variant_set %>%
-      dplyr::mutate(CHROM = paste0("chr", CHROM))
+      dplyr::mutate(CHROM = paste0("chr", .data$CHROM))
   }
 
   kataegis_data <- pcgrr::kataegis_input(variant_set, chr = "CHROM",
@@ -258,7 +258,7 @@ generate_report_data_kataegis <- function(variant_set,
                                build = build)
     }
   }else{
-    pcgrr:::log4r_info(
+    log4r_info(
       paste0(
         "No or too few SNVs (< 100) found in input - skipping kataegis detection"))
     #pcg_report_kataegis[["eval"]] <- FALSE

--- a/src/R/pcgrr/R/msi.R
+++ b/src/R/pcgrr/R/msi.R
@@ -9,7 +9,7 @@
 #' @param sample_name name of sample
 #' @return msi_data
 #'
-#'
+#' @export
 predict_msi_status <- function(vcf_data_df, pcgr_data,
                                msi_prediction_model,
                                msi_prediction_dataset,
@@ -20,71 +20,71 @@ predict_msi_status <- function(vcf_data_df, pcgr_data,
     chromosome_column = "CHROM",
     bsg = pcgr_data[["assembly"]][["bsg"]])
   mutations_valid <- mutations_valid %>%
-    dplyr::select(CHROM, POS, REF, ALT, CONSEQUENCE, SYMBOL,
-                  GENOMIC_CHANGE, VARIANT_CLASS, PROTEIN_DOMAIN,
-                  GENE_NAME, PROTEIN_CHANGE, MUTATION_HOTSPOT,
-                  CLINVAR, TCGA_FREQUENCY, AF_TUMOR, DP_TUMOR,
-                  AF_CONTROL, DP_CONTROL, CALL_CONFIDENCE,
-                  SIMPLEREPEATS_HIT, WINMASKER_HIT)
+    dplyr::select(.data$CHROM, .data$POS, .data$REF, .data$ALT, .data$CONSEQUENCE, .data$SYMBOL,
+                  .data$GENOMIC_CHANGE, .data$VARIANT_CLASS, .data$PROTEIN_DOMAIN,
+                  .data$GENE_NAME, .data$PROTEIN_CHANGE, .data$MUTATION_HOTSPOT,
+                  .data$CLINVAR, .data$TCGA_FREQUENCY, .data$AF_TUMOR, .data$DP_TUMOR,
+                  .data$AF_CONTROL, .data$DP_CONTROL, .data$CALL_CONFIDENCE,
+                  .data$SIMPLEREPEATS_HIT, .data$WINMASKER_HIT)
 
   vcf_df_repeatAnnotated <- mutations_valid %>%
     dplyr::mutate(repeatStatus =
-                    dplyr::if_else(SIMPLEREPEATS_HIT == T,
+                    dplyr::if_else(.data$SIMPLEREPEATS_HIT == T,
                                    "simpleRepeat", as.character(NA))) %>%
     dplyr::mutate(winMaskStatus =
-                    dplyr::if_else(WINMASKER_HIT == T,
+                    dplyr::if_else(.data$WINMASKER_HIT == T,
                                    "winMaskDust", as.character(NA)))
 
   msi_stats <- data.frame("sample_name" = sample_name, stringsAsFactors = F)
 
   msi_stats1 <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(!is.na(repeatStatus) & (VARIANT_CLASS == "insertion" |
-                                            VARIANT_CLASS == "deletion")) %>%
+    dplyr::filter(!is.na(.data$repeatStatus) & (.data$VARIANT_CLASS == "insertion" |
+                                            .data$VARIANT_CLASS == "deletion")) %>%
     dplyr::summarise(repeat_indels = dplyr::n())
 
   msi_stats2 <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(!is.na(repeatStatus) & VARIANT_CLASS == "SNV") %>%
+    dplyr::filter(!is.na(.data$repeatStatus) & .data$VARIANT_CLASS == "SNV") %>%
     dplyr::summarise(repeat_SNVs = dplyr::n())
 
   msi_stats3 <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(!is.na(repeatStatus)) %>%
+    dplyr::filter(!is.na(.data$repeatStatus)) %>%
     dplyr::summarise(repeat_indelSNVs = dplyr::n())
 
   winmask_indels <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(!is.na(winMaskStatus) &
-                    (VARIANT_CLASS == "insertion" |
-                       VARIANT_CLASS == "deletion")) %>%
+    dplyr::filter(!is.na(.data$winMaskStatus) &
+                    (.data$VARIANT_CLASS == "insertion" |
+                       .data$VARIANT_CLASS == "deletion")) %>%
     dplyr::summarise(winmask_indels = dplyr::n())
 
   winmask_snvs <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(!is.na(winMaskStatus) & VARIANT_CLASS == "SNV") %>%
+    dplyr::filter(!is.na(.data$winMaskStatus) & .data$VARIANT_CLASS == "SNV") %>%
     dplyr::summarise(winmask_SNVs = dplyr::n())
 
   winmask_tot <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(!is.na(winMaskStatus)) %>%
+    dplyr::filter(!is.na(.data$winMaskStatus)) %>%
     dplyr::summarise(winmask_indelSNVs = dplyr::n())
 
   msi_stats4 <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(is.na(repeatStatus) &
-                    (VARIANT_CLASS == "insertion" |
-                       VARIANT_CLASS == "deletion")) %>%
+    dplyr::filter(is.na(.data$repeatStatus) &
+                    (.data$VARIANT_CLASS == "insertion" |
+                       .data$VARIANT_CLASS == "deletion")) %>%
     dplyr::summarise(nonRepeat_indels = dplyr::n())
 
   msi_stats5 <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(is.na(repeatStatus) & VARIANT_CLASS == "SNV") %>%
+    dplyr::filter(is.na(.data$repeatStatus) & .data$VARIANT_CLASS == "SNV") %>%
     dplyr::summarise(nonRepeat_SNVs = dplyr::n())
 
   msi_stats6 <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(is.na(repeatStatus)) %>%
+    dplyr::filter(is.na(.data$repeatStatus)) %>%
     dplyr::summarise(nonRepeat_indelSNVs = dplyr::n())
 
   msi_stats7 <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(VARIANT_CLASS == "insertion" |
-                    VARIANT_CLASS == "deletion") %>%
+    dplyr::filter(.data$VARIANT_CLASS == "insertion" |
+                    .data$VARIANT_CLASS == "deletion") %>%
     dplyr::summarise(indels = dplyr::n())
 
   msi_stats8 <- vcf_df_repeatAnnotated %>%
-    dplyr::filter(VARIANT_CLASS == "SNV") %>%
+    dplyr::filter(.data$VARIANT_CLASS == "SNV") %>%
     dplyr::summarise(SNVs = dplyr::n())
 
   msi_stats9 <- vcf_df_repeatAnnotated %>%
@@ -92,68 +92,68 @@ predict_msi_status <- function(vcf_data_df, pcgr_data,
 
   msi_stats10 <- vcf_df_repeatAnnotated %>%
     dplyr::filter(
-      SYMBOL == "MLH1" &
+      .data$SYMBOL == "MLH1" &
         stringr::str_detect(
-          CONSEQUENCE,
+          .data$CONSEQUENCE,
           "frameshift_|missense_|splice_|stop_|start_|inframe_")) %>%
     dplyr::summarise(MLH1 = dplyr::n())
 
   msi_stats11 <- vcf_df_repeatAnnotated %>%
     dplyr::filter(
-      SYMBOL == "MLH3" &
+      .data$SYMBOL == "MLH3" &
         stringr::str_detect(
-          CONSEQUENCE,
+          .data$CONSEQUENCE,
           "frameshift_|missense_|splice_|stop_|start_|inframe_")) %>%
     dplyr::summarise(MLH3 = dplyr::n())
 
   msi_stats12 <- vcf_df_repeatAnnotated %>%
     dplyr::filter(
-      SYMBOL == "MSH2" &
+      .data$SYMBOL == "MSH2" &
         stringr::str_detect(
-          CONSEQUENCE,
+          .data$CONSEQUENCE,
           "frameshift_|missense_|splice_|stop_|start_|inframe_")) %>%
     dplyr::summarise(MSH2 = dplyr::n())
 
   msi_stats13 <- vcf_df_repeatAnnotated %>%
     dplyr::filter(
-      SYMBOL == "MSH3" &
+      .data$SYMBOL == "MSH3" &
         stringr::str_detect(
-          CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
+          .data$CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
     dplyr::summarise(MSH3 = dplyr::n())
 
   msi_stats14 <- vcf_df_repeatAnnotated %>%
     dplyr::filter(
-      SYMBOL == "MSH6" &
+      .data$SYMBOL == "MSH6" &
         stringr::str_detect(
-          CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
+          .data$CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
     dplyr::summarise(MSH6 = dplyr::n())
 
   msi_stats15 <- vcf_df_repeatAnnotated %>%
     dplyr::filter(
-      SYMBOL == "PMS1" &
+      .data$SYMBOL == "PMS1" &
         stringr::str_detect(
-          CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
+          .data$CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
     dplyr::summarise(PMS1 = dplyr::n())
 
   msi_stats16 <- vcf_df_repeatAnnotated %>%
     dplyr::filter(
-      SYMBOL == "PMS2" &
+      .data$SYMBOL == "PMS2" &
         stringr::str_detect(
-          CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
+          .data$CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
     dplyr::summarise(PMS2 = dplyr::n())
 
   msi_stats17 <- vcf_df_repeatAnnotated %>%
     dplyr::filter(
-      SYMBOL == "POLE" &
+      .data$SYMBOL == "POLE" &
         stringr::str_detect(
-          CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
+          .data$CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
     dplyr::summarise(POLE = dplyr::n())
 
   msi_stats18 <- vcf_df_repeatAnnotated %>%
     dplyr::filter(
-      SYMBOL == "POLD1" &
+      .data$SYMBOL == "POLD1" &
         stringr::str_detect(
-          CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
+          .data$CONSEQUENCE, "frameshift_|missense_|splice_|stop_|start_|frame_")) %>%
     dplyr::summarise(POLD1 = dplyr::n())
 
   msi_stats1$sample_name <- sample_name
@@ -224,15 +224,15 @@ predict_msi_status <- function(vcf_data_df, pcgr_data,
 
   mmr_pol_df <- mutations_valid %>%
     dplyr::filter(
-      stringr::str_detect(SYMBOL,
+      stringr::str_detect(.data$SYMBOL,
                           "^(MLH1|MLH3|MSH2|MSH3|MSH6|PMS1|PMS2|POLD1|POLE)$") &
-        stringr::str_detect(CONSEQUENCE,
+        stringr::str_detect(.data$CONSEQUENCE,
                             "frameshift_|missense_|splice_|stop_|inframe_"))
-  mmr_pol_df <- dplyr::select(mmr_pol_df, -c(CHROM, POS, REF, ALT))
-  mmr_pol_df <- dplyr::rename(mmr_pol_df, GENE = SYMBOL)
+  mmr_pol_df <- dplyr::select(mmr_pol_df, -c(.data$CHROM, .data$POS, .data$REF, .data$ALT))
+  mmr_pol_df <- dplyr::rename(mmr_pol_df, GENE = .data$SYMBOL)
   mmr_pol_df <- mmr_pol_df %>%
-    dplyr::select(GENE, CONSEQUENCE, PROTEIN_CHANGE,
-                  GENE_NAME, VARIANT_CLASS, PROTEIN_DOMAIN,
+    dplyr::select(.data$GENE, .data$CONSEQUENCE, .data$PROTEIN_CHANGE,
+                  .data$GENE_NAME, .data$VARIANT_CLASS, .data$PROTEIN_DOMAIN,
                   dplyr::everything())
 
   msi_predictors <- c("fracWinMaskIndels", "fracWinMaskSNVs",
@@ -242,7 +242,7 @@ predict_msi_status <- function(vcf_data_df, pcgr_data,
                       "MSH3", "MSH6", "PMS1",
                       "PMS2", "POLD1", "POLE", "tmb",
                       "tmb_indel", "tmb_snv")
-  msi_class <- predict(msi_prediction_model,
+  msi_class <- stats::predict(msi_prediction_model,
                        dplyr::select(msi_stats, msi_predictors))
   if (msi_class == "MSS") {
     msi_stats$predicted_class <- "MSS (Microsatellite stable)"
@@ -254,9 +254,9 @@ predict_msi_status <- function(vcf_data_df, pcgr_data,
     #msi_stats$vb <- "MSI status:\nMSI - High"
     msi_stats$vb <- "MSI - High"
   }
-  pcgrr:::log4r_info(paste0("Predicted MSI status: ",
+  log4r_info(paste0("Predicted MSI status: ",
                            msi_stats$predicted_class))
-  pcgrr:::log4r_info(paste0("MSI - Indel fraction: ",
+  log4r_info(paste0("MSI - Indel fraction: ",
                            round(msi_stats$fracNonRepeatIndels, digits = 3)))
   msi_data <- list("mmr_pol_variants" = mmr_pol_df,
                    "msi_stats" = msi_stats,
@@ -273,6 +273,7 @@ predict_msi_status <- function(vcf_data_df, pcgr_data,
 #' @param sample_name sample identifier
 #' @param pcgr_config Object with PCGR configuration parameters
 #'
+#' @export
 generate_report_data_msi <- function(sample_calls,
                                      pcgr_data,
                                      sample_name,
@@ -280,11 +281,11 @@ generate_report_data_msi <- function(sample_calls,
 
   pcg_report_msi <- pcgrr::init_report(config =pcgr_config,
                                        class = "msi")
-  pcgrr:::log4r_info("------")
-  pcgrr:::log4r_info("Predicting microsatellite instability status")
+  log4r_info("------")
+  log4r_info("Predicting microsatellite instability status")
 
-  msi_sample_calls <- sample_calls %>% dplyr::filter(EXONIC_STATUS == "exonic")
-  pcgrr:::log4r_info(paste0("n = ",
+  msi_sample_calls <- sample_calls %>% dplyr::filter(.data$EXONIC_STATUS == "exonic")
+  log4r_info(paste0("n = ",
                            nrow(msi_sample_calls),
                            " exonic variants used for MSI prediction"))
   if (nrow(msi_sample_calls) >= 1) {
@@ -298,7 +299,7 @@ generate_report_data_msi <- function(sample_calls,
     pcg_report_msi[["eval"]] <- TRUE
   }
   else{
-    pcgrr:::log4r_info("Missing variants for MSI prediction")
+    log4r_info("Missing variants for MSI prediction")
     pcg_report_msi[["missing_data"]] <- TRUE
   }
 
@@ -313,17 +314,17 @@ generate_report_data_msi <- function(sample_calls,
 #' @param indel_fraction fraction of indels of all mutations (SNVs + indels)
 #' @return p
 #'
-#'
+#' @export
 
 msi_indel_fraction_plot <- function(tcga_msi_dataset, indel_fraction) {
 
-  color_vec <- head(pcgrr::color_palette[["tier"]][["values"]],2)
+  color_vec <- utils::head(pcgrr::color_palette[["tier"]][["values"]],2)
   names(color_vec) <- c("MSS", "MSI.H")
 
   p <- ggplot2::ggplot(data = tcga_msi_dataset) +
-    ggplot2::geom_histogram(mapping = ggplot2::aes(x = fracIndels,
-                                                   color = MSI_status,
-                                                   fill = MSI_status),
+    ggplot2::geom_histogram(mapping = ggplot2::aes(x = .data$fracIndels,
+                                                   color = .data$MSI_status,
+                                                   fill = .data$MSI_status),
                             position = "dodge", binwidth = 0.01) +
     ggplot2::ylab("Number of TCGA samples") +
     ggplot2::scale_fill_manual(values = color_vec) +

--- a/src/R/pcgrr/R/mutation.R
+++ b/src/R/pcgrr/R/mutation.R
@@ -1,11 +1,10 @@
-
-
 #' Function that assigns one of six mutation types to a list of mutations
 #'
 #' @param var_df data frame with variants
 #'
 #' @return var_df
 #'
+#' @export
 assign_mutation_type <- function(var_df) {
 
   invisible(
@@ -52,7 +51,7 @@ assign_mutation_type <- function(var_df) {
 #' @param tier_df data frame with somatic mutations
 #' @return maf_df
 #'
-#'
+#' @export
 get_proper_maf_alleles <- function(maf_df, genome_seq, seqinfo) {
 
   maf_df_valid <-
@@ -60,17 +59,17 @@ get_proper_maf_alleles <- function(maf_df, genome_seq, seqinfo) {
                                  chromosome_column = "Chromosome",
                                  bsg = genome_seq)
   if ("end" %in% colnames(maf_df_valid)) {
-    maf_df_valid <- dplyr::select(maf_df_valid, -end)
+    maf_df_valid <- dplyr::select(maf_df_valid, -.data$end)
   }
 
   maf_snv <- maf_df_valid %>%
-    dplyr::filter(Variant_Type == "SNP") %>%
-    dplyr::mutate(REF = Reference_Allele,
-                  ALT = Tumor_Seq_Allele2, POS = Start_Position)
+    dplyr::filter(.data$Variant_Type == "SNP") %>%
+    dplyr::mutate(REF = .data$Reference_Allele,
+                  ALT = .data$Tumor_Seq_Allele2, POS = .data$Start_Position)
 
   maf_all <- maf_snv
-  maf_ins <- dplyr::filter(maf_df_valid, Variant_Type == "INS")
-  maf_del <- dplyr::filter(maf_df_valid, Variant_Type == "DEL")
+  maf_ins <- dplyr::filter(maf_df_valid, .data$Variant_Type == "INS")
+  maf_del <- dplyr::filter(maf_df_valid, .data$Variant_Type == "DEL")
 
   if (nrow(maf_del) > 0) {
     ## get appropriate alleles (VCF-like) of reference and alternate (DELETIONS)

--- a/src/R/pcgrr/R/mutational_burden.R
+++ b/src/R/pcgrr/R/mutational_burden.R
@@ -6,7 +6,7 @@
 #' @param pcgr_config Object with PCGR configuration parameters
 #'
 #' @return pcg_report_data data frame with all report elements
-#'
+#' @export
 generate_report_data_tmb <- function(sample_calls,
                                      pcgr_data,
                                      sample_name, pcgr_config) {
@@ -14,8 +14,8 @@ generate_report_data_tmb <- function(sample_calls,
   tmb_consequence_pattern <-
     "^(stop_|start_lost|frameshift_|missense_|synonymous_|inframe_)"
 
-  pcgrr:::log4r_info("------")
-  pcgrr:::log4r_info(paste0("Calculating tumor mutational burden"))
+  log4r_info("------")
+  log4r_info(paste0("Calculating tumor mutational burden"))
 
   pcg_report_tmb <-
     pcgrr::init_report(config = pcgr_config,
@@ -34,7 +34,7 @@ generate_report_data_tmb <- function(sample_calls,
     pcg_report_tmb[["v_stat"]][["n_tmb"]] <-
       sample_calls %>%
       dplyr::filter(
-        stringr::str_detect(CONSEQUENCE, tmb_consequence_pattern)) %>%
+        stringr::str_detect(.data$CONSEQUENCE, tmb_consequence_pattern)) %>%
       nrow()
   }
 
@@ -46,13 +46,13 @@ generate_report_data_tmb <- function(sample_calls,
                      pcg_report_tmb[["v_stat"]][["target_size_mb"]]),
         digits = 2)
   }
-  pcgrr:::log4r_info(
+  log4r_info(
     paste0("Number of variants for mutational burden analysis: ",
            pcg_report_tmb[["v_stat"]][["n_tmb"]]))
-  pcgrr:::log4r_info(
+  log4r_info(
     paste0("Coding target size sequencing assay (Mb): ",
            pcg_report_tmb[["v_stat"]][["target_size_mb"]]))
-  pcgrr:::log4r_info(
+  log4r_info(
     paste0("Estimated mutational burden: ",
            pcg_report_tmb[["v_stat"]][["tmb_estimate"]],
            " mutations/Mb"))
@@ -60,6 +60,7 @@ generate_report_data_tmb <- function(sample_calls,
   return(pcg_report_tmb)
 }
 
+#' @export
 plot_tmb_primary_site_tcga <- function(tcga_tmb, p_site = "Liver",
                                        tmb_estimate = 5,
                                        algorithm = "all_coding") {
@@ -68,34 +69,34 @@ plot_tmb_primary_site_tcga <- function(tcga_tmb, p_site = "Liver",
   tmb_site_colors <- data.frame(primary_site =
                                   unique(tcga_tmb$primary_site),
                                 stringsAsFactors = F) %>%
-    dplyr::filter(!is.na(primary_site))
+    dplyr::filter(!is.na(.data$primary_site))
   tmb_site_colors$color <- "#f0f0f0"
   tmb_site_colors <-
     dplyr::mutate(tmb_site_colors,
                   color = dplyr::if_else(
-                    primary_site == p_site,
-                    pcgrr::color_palette[["tier"]][["values"]][1], color))
+                    .data$primary_site == p_site,
+                    pcgrr::color_palette[["tier"]][["values"]][1], .data$color))
 
   tmb_site_color_vec <- tmb_site_colors$color
   names(tmb_site_color_vec) <- tmb_site_colors$primary_site
 
   tcga_tmb <- tcga_tmb %>%
-    dplyr::filter(!is.na(primary_site)) %>%
-    dplyr::select(primary_site, tmb_log10, tmb)
+    dplyr::filter(!is.na(.data$primary_site)) %>%
+    dplyr::select(.data$primary_site, .data$tmb_log10, .data$tmb)
 
   if (algorithm == "nonsyn") {
     tcga_tmb <- tcga_tmb %>%
-      dplyr::filter(!is.na(primary_site)) %>%
-      dplyr::select(primary_site, tmb_ns_log10, tmb_ns) %>%
-      dplyr::rename(tmb = tmb_ns, tmb_log10 = tmb_ns_log10)
+      dplyr::filter(!is.na(.data$primary_site)) %>%
+      dplyr::select(.data$primary_site, .data$tmb_ns_log10, .data$tmb_ns) %>%
+      dplyr::rename(tmb = .data$tmb_ns, tmb_log10 = .data$tmb_ns_log10)
   }
 
   tmb_plot_site <-
     ggplot2::ggplot(data = tcga_tmb) +
     ggplot2::geom_boxplot(mapping =
-                            ggplot2::aes(x = reorder(primary_site, tmb_log10,
-                                                     FUN = median),
-                                         y = tmb, fill = primary_site)) +
+                            ggplot2::aes(x = stats::reorder(.data$primary_site, .data$tmb_log10,
+                                                     FUN = stats::median),
+                                         y = .data$tmb, fill = .data$primary_site)) +
     ggplot2::theme_classic() +
     ggplot2::scale_y_continuous(trans = scales::log_trans(base = 10),
                                 breaks = c(0.01, 1, 10, 100, 1000),

--- a/src/R/pcgrr/R/report.R
+++ b/src/R/pcgrr/R/report.R
@@ -7,7 +7,7 @@
 #' @param type Type of report ('somatic' or 'germline')
 #' @param virtual_panel_id identifier(s) for virtual panel id
 #' @param custom_bed custom BED file with target loci for screening
-
+#' @export
 init_report <- function(config = NULL,
                         class = NULL,
                         pcgr_data = NULL,
@@ -50,7 +50,7 @@ init_report <- function(config = NULL,
     if (!is.null(pcgr_data)) {
       report[["metadata"]][["phenotype_ontology"]][["oncotree_query"]] <-
         dplyr::filter(pcgr_data[["phenotype_ontology"]][["oncotree"]],
-                      is.na(primary_site))
+                      is.na(.data$primary_site))
     }
 
     report[["content"]][["snv_indel"]] <-
@@ -75,14 +75,14 @@ init_report <- function(config = NULL,
         tumor_group_entry <-
           dplyr::filter(
             pcgr_data[["phenotype_ontology"]][["cancer_groups"]],
-            primary_site == config[["t_props"]][["tumor_type"]])
+            .data$primary_site == config[["t_props"]][["tumor_type"]])
         if (nrow(tumor_group_entry) == 1) {
           report[["metadata"]][["phenotype_ontology"]][["oncotree_query"]] <-
             dplyr::filter(
               pcgr_data[["phenotype_ontology"]][["oncotree"]],
-              primary_site == config[["t_props"]][["tumor_type"]])
+              .data$primary_site == config[["t_props"]][["tumor_type"]])
         }else{
-          pcgrr:::log4r_info(paste0("Cannot find tumor type ",
+          log4r_info(paste0("Cannot find tumor type ",
                                    config[["t_props"]][["tumor_type"]],
                                    " in list of primary sites"))
           report[["metadata"]][["phenotype_ontology"]][["oncotree_query"]] <-
@@ -190,7 +190,7 @@ init_report <- function(config = NULL,
 #' @param report PCGR final report
 #' @param report_data Object with PCGR report data
 #' @param a_elem section of PCGR report
-
+#' @export
 update_report <- function(report, report_data,
                           a_elem = "snv_indel") {
 
@@ -207,6 +207,7 @@ update_report <- function(report, report_data,
   return(report)
 }
 
+#' @export
 set_report_metadata <- function(config,
                                 pcgr_data,
                                 virtual_panel_id = "-1",
@@ -252,28 +253,28 @@ set_report_metadata <- function(config,
     for(pid in panel_ids){
       p <- as.integer(pid)
       panel_genes <- pcgr_data[["virtual_gene_panels"]] %>%
-        dplyr::filter(id == p) %>%
-        dplyr::select(symbol,
-                      ensembl_gene_id,
-                      confidence_level,
-                      panel_name,
-                      panel_id,
-                      id,
-                      panel_version,
-                      panel_url,
-                      entrezgene,
-                      genename)
+        dplyr::filter(.data$id == p) %>%
+        dplyr::select(.data$symbol,
+                      .data$ensembl_gene_id,
+                      .data$confidence_level,
+                      .data$panel_name,
+                      .data$panel_id,
+                      .data$id,
+                      .data$panel_version,
+                      .data$panel_url,
+                      .data$entrezgene,
+                      .data$genename)
 
       report_metadata[["gene_panel"]][["genes"]] <-
         report_metadata[["gene_panel"]][["genes"]] %>%
         dplyr::bind_rows(panel_genes) %>%
-        dplyr::arrange(symbol)
+        dplyr::arrange(.data$symbol)
     }
 
     if (config[["diagnostic_grade_only"]] == T) {
       report_metadata[["gene_panel"]][["genes"]] <-
         report_metadata[["gene_panel"]][["genes"]] %>%
-        dplyr::filter(confidence_level == 3 | confidence_level == 4)
+        dplyr::filter(.data$confidence_level == 3 | .data$confidence_level == 4)
     }
 
 
@@ -300,18 +301,18 @@ set_report_metadata <- function(config,
 
       panels_included <-
         report_metadata$gene_panel$genes %>%
-        dplyr::select(id, panel_url, panel_name) %>%
-        dplyr::arrange(id) %>%
+        dplyr::select(.data$id, .data$panel_url, .data$panel_name) %>%
+        dplyr::arrange(.data$id) %>%
         dplyr::distinct() %>%
-        dplyr::mutate(link = paste0("<li><a href='",panel_url,
+        dplyr::mutate(link = paste0("<li><a href='",.data$panel_url,
                                     "' target='_blank'>",
-                                    panel_name,"</a></li>"))
+                                    .data$panel_name,"</a></li>"))
 
       report_metadata[["gene_panel"]][["genes"]] <-
         report_metadata[["gene_panel"]][["genes"]] %>%
-        dplyr::select(-c(panel_id,panel_name, confidence_level,
-                         panel_version,panel_url,
-                         id)) %>%
+        dplyr::select(-c(.data$panel_id, .data$panel_name, .data$confidence_level,
+                         .data$panel_version, .data$panel_url,
+                         .data$id)) %>%
         dplyr::mutate(panel_version = NA, confidence_level = 5,
                       panel_id = NA, panel_url = NA) %>%
         dplyr::distinct()
@@ -348,17 +349,18 @@ set_report_metadata <- function(config,
         report_metadata[["gene_panel"]][["confidence"]] <-
           "User-defined panel (custom geneset from panel 0)"
       }else{
-        pcgrr:::log4r_warn(
+        log4r_warn(
           paste0("Custom BED file (", custom_bed,
                  ") does not contain regions that overlap ",
                  "protein-coding transcripts (regulatory/exonic)"))
-        pcgrr:::log4r_info("Quitting report generation")
+        log4r_info("Quitting report generation")
       }
     }
   }
   return(report_metadata)
 }
 
+#' @export
 init_tmb_content <- function(tcga_tmb = NULL, config = NULL){
 
   invisible(assertthat::assert_that(!is.null(tcga_tmb)))
@@ -385,6 +387,7 @@ init_tmb_content <- function(tcga_tmb = NULL, config = NULL){
   return(rep)
 }
 
+#' @export
 init_cna_content <- function(rep = NULL){
 
   invisible(assertthat::assert_that(!is.null(rep)))
@@ -411,6 +414,7 @@ init_cna_content <- function(rep = NULL){
 
 }
 
+#' @export
 init_snv_indel_content <- function(rep = NULL){
 
   invisible(assertthat::assert_that(!is.null(rep)))
@@ -441,6 +445,7 @@ init_snv_indel_content <- function(rep = NULL){
   return(rep)
 }
 
+#' @export
 init_m_signature_content <- function(){
 
   rep <- list()
@@ -470,6 +475,7 @@ init_m_signature_content <- function(){
 #init_msi_content <- function(){}
 #init_kataegis_content <- function(){}
 
+#' @export
 init_rainfall_content <- function(){
 
   rep <- list()
@@ -494,6 +500,7 @@ init_rainfall_content <- function(){
 
 }
 
+#' @export
 init_tumor_only_content <- function(){
 
   rep <- list()
@@ -522,6 +529,7 @@ init_tumor_only_content <- function(){
   return(rep)
 }
 
+#' @export
 init_valuebox_content <- function(){
   rep <- list()
 
@@ -550,6 +558,7 @@ init_valuebox_content <- function(){
 
 }
 
+#' @export
 init_report_display_content <- function(){
 
   rep <- list()
@@ -564,7 +573,10 @@ init_report_display_content <- function(){
   return(rep)
 
 }
+
 #init_ctrial_content <- function(){}
+
+#' @export
 init_var_content <- function(){
 
   rep <- list()
@@ -587,6 +599,7 @@ init_var_content <- function(){
   return(rep)
 }
 
+#' @export
 init_germline_content <- function(){
   rep <- list()
 

--- a/src/R/pcgrr/R/utils_shortcuts.R
+++ b/src/R/pcgrr/R/utils_shortcuts.R
@@ -1,0 +1,20 @@
+#' Pipe operator
+#'
+#' See \code{magrittr::\link[magrittr]{\%>\%}} for details.
+#'
+#' @name %>%
+#' @rdname pipe
+#' @keywords internal
+#' @importFrom magrittr %>%
+NULL
+
+#' Tidy eval helpers
+#'
+#' <https://cran.r-project.org/web/packages/dplyr/vignettes/programming.html>
+#'
+#' @name tidyeval
+#' @keywords internal
+#' @importFrom rlang .data :=
+NULL
+
+utils::globalVariables(c("."))

--- a/src/R/pcgrr/R/value_boxes.R
+++ b/src/R/pcgrr/R/value_boxes.R
@@ -5,7 +5,7 @@
 #' @param pcg_report pcg report with list elements
 #' @return p
 #'
-#'
+#' @export
 
 plot_value_boxes <- function(pcg_report) {
   df <- data.frame(
@@ -37,8 +37,8 @@ plot_value_boxes <- function(pcg_report) {
     color <- rep(pcgrr::color_palette[["report_color"]][["values"]][2], 9)
   }
 
-  p <- ggplot2::ggplot(df, ggplot2::aes(x, y, height = h, width = w,
-                                        label = info, fill = color)) +
+  p <- ggplot2::ggplot(df, ggplot2::aes(.data$x, .data$y, height = .data$h, width = .data$w,
+                                        label = .data$info, fill = color)) +
     ggplot2::geom_tile() +
     ggplot2::geom_text(color = "white", fontface = "bold", size = 7) +
     ggplot2::coord_fixed() +
@@ -57,6 +57,7 @@ plot_value_boxes <- function(pcg_report) {
 #' @param sample_name sample identifier
 #' @param pcgr_config Object with PCGR configuration parameters
 #'
+#' @export
 generate_report_data_value_box <- function(pcg_report,
                                            pcgr_data,
                                            sample_name,
@@ -64,8 +65,8 @@ generate_report_data_value_box <- function(pcg_report,
 
   pcg_report_value_box <- pcgrr::init_report(config = pcgr_config,
                                              class = "value_box")
-  pcgrr:::log4r_info("------")
-  pcgrr:::log4r_info("Assigning elements to PCGR value boxes")
+  log4r_info("------")
+  log4r_info("Assigning elements to PCGR value boxes")
 
   if (!pcg_report[["content"]][["snv_indel"]][["eval"]]) {
     return(pcg_report_value_box)
@@ -81,7 +82,7 @@ generate_report_data_value_box <- function(pcg_report,
     if (!is.null(sig_contributions)) {
       if (nrow(sig_contributions[["per_group"]]) > 0) {
         ranked_groups <- sig_contributions[["per_group"]] %>%
-          dplyr::arrange(desc(prop_group))
+          dplyr::arrange(dplyr::desc(.data$prop_group))
 
         dominant_aetiology <- ranked_groups[1, "group"]
         # pcg_report_value_box[["signatures"]] <-
@@ -96,7 +97,7 @@ generate_report_data_value_box <- function(pcg_report,
       num_events <- NROW(rep_cont$kataegis$events)
       if(num_events > 0){
         num_events <- NROW(rep_cont$kataegis$events %>%
-                             dplyr::filter(confidence == 3))
+                             dplyr::filter(.data$confidence == 3))
         # pcg_report_value_box[["kataegis"]] <-
         #   paste0("Kataegis events:\n", num_events)
         pcg_report_value_box[["kataegis"]] <- num_events
@@ -149,7 +150,7 @@ generate_report_data_value_box <- function(pcg_report,
           #   "SCNAs:\n",
             paste(
               unique(
-                head(
+                utils::head(
                   rep_cont[["cna"]][["disp"]][["tier1"]]$SYMBOL, 2)
                 ),
               collapse = ", ")
@@ -170,10 +171,10 @@ generate_report_data_value_box <- function(pcg_report,
             unlist(rep_cont[["snv_indel"]][["variant_set"]][["tier1"]]$SYMBOL)
             )
         pcg_report_value_box[["tier1"]] <-
-          paste(head(tier1_genes, 2), collapse = ", ")
+          paste(utils::head(tier1_genes, 2), collapse = ", ")
         if (length(tier1_genes) > 2) {
           pcg_report_value_box[["tier1"]] <-
-            paste(paste(head(tier1_genes, 2), collapse = ", "),
+            paste(paste(utils::head(tier1_genes, 2), collapse = ", "),
                   paste(tier1_genes[3:min(4, length(tier1_genes))],
                         collapse = ", "),
                   sep = "\n")
@@ -193,10 +194,10 @@ generate_report_data_value_box <- function(pcg_report,
             unlist(
               rep_cont[["snv_indel"]][["variant_set"]][["tier2"]]$SYMBOL))
         pcg_report_value_box[["tier2"]] <-
-          paste(head(tier2_genes, 2), collapse = ", ")
+          paste(utils::head(tier2_genes, 2), collapse = ", ")
         if (length(tier2_genes) > 2) {
           pcg_report_value_box[["tier2"]] <-
-            paste(paste(head(tier2_genes, 2), collapse = ", "),
+            paste(paste(utils::head(tier2_genes, 2), collapse = ", "),
                   paste(tier2_genes[3:min(4, length(tier2_genes))],
                         collapse = ", "),
                   sep = "\n")


### PR DESCRIPTION
Part 1 of lots of syntactic changes:

- Exporting functions
- Using `.data$` in all tidyverse functions (see the `Eliminating R CMD check NOTEs` part under <https://cran.r-project.org/web/packages/dplyr/vignettes/programming.html>)
- `log4r_*` functions don't need the `pcgrr:::` prefix since they're inside the package anyhow.
- Import `pipe`, `.data`, `.` and `:=` globally so that they can be used without explicit import in every function
- Specify missing import packages:
  - `GenomeInfoDb::` for `seqlengths` and `seqnames`
  - `IRanges::IRanges`
  - `S4Vectors::Rle`
  - `dplyr::desc`
  - `utils::head`
  - `stats::` for `na.omit`, `reorder`, `median`, and `setNames`
    - `stats::predict` (I _think_ that's the pkg `predict` comes from?)