### PR TITLE
Update Rscript pcgrr.R paths

### DIFF
--- a/conda/env/pcgr.yml
+++ b/conda/env/pcgr.yml
@@ -8,3 +8,4 @@ channels:
 
 dependencies:
   - pcgr
+  - pandoc =2.16 # for pcgrr.R

--- a/pcgr/main.py
+++ b/pcgr/main.py
@@ -469,8 +469,6 @@ def run_pcgr(arg_dict, host_directories, config_options, DOCKER_IMAGE_VERSION):
         # export PATH to R conda env Rscript
         rscript = rscript_path(DOCKER_IMAGE_VERSION)
         pcgrr_script = pcgrr_script_path(DOCKER_IMAGE_VERSION)
-        print(rscript)
-        print(pcgrr_script)
         pcgr_report_command = (
                 f"{docker_cmd_run1} "
                 f"{rscript} {pcgrr_script} "
@@ -546,7 +544,7 @@ def run_pcgr(arg_dict, host_directories, config_options, DOCKER_IMAGE_VERSION):
                 )
 
         if debug:
-          print(pcgr_report_command)
+            print(pcgr_report_command)
         check_subprocess(logger, pcgr_report_command, debug)
         logger.info("Finished")
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pcgr',
-    version='0.9.2',
+    version='0.9.3.9000',
     license='MIT',
     author='Sigve Nakken',
     author_email='sigven@gmail.com',


### PR DESCRIPTION
The conda env exporting had an important flaw in that it would look at the _host_ `PATH` when running in docker mode, not the _container's_ `PATH`.
I've now added a hardcoded `/opt/mambaforge/envs` in the case when the Docker container is used. When the `--no_docker` flag is used, that translates to `/path/to/user/conda/envs`.

I've also added `pandoc` into the _pcgr_ env, since that's the activated env throughout the pipeline. Basically when you call `/path/to/user/conda/envs/pcgr/Rscript pcgrr.R`, it will look in the `pcgrr` R library for all R packages, but the `pandoc` command that runs with `rmarkdown::...` looks for the system (i.e. `pcgr` env's) `pandoc`.
Hope that kinda makes sense!

Btw, I've tested this both with local conda and docker mode, and it works with both.