### PR TITLE
Fix "desc() must be called with exactly one argument" in report gen

### DIFF
--- a/pcgrr/R/clinicaltrials.R
+++ b/pcgrr/R/clinicaltrials.R
@@ -55,9 +55,10 @@ generate_report_data_trials <- function(pcgr_data, config, sample_name) {
       dplyr::rename(intervention = .data$intervention2) %>%
       magrittr::set_colnames(toupper(names(.))) %>%
       dplyr::arrange(.data$N_PRIMARY_CANCER_SITES,
-                     .data$OVERALL_STATUS, dplyr::desc(.data$START_DATE),
-                     dplyr::desc(nchar(.data$BIOMARKER_INDEX),
-                          .data$STUDY_DESIGN_PRIMARY_PURPOSE)) %>%
+                     .data$OVERALL_STATUS,
+                     dplyr::desc(.data$START_DATE),
+                     dplyr::desc(nchar(.data$BIOMARKER_INDEX)),
+                     dplyr::desc(.data$STUDY_DESIGN_PRIMARY_PURPOSE)) %>%
       dplyr::select(-c(.data$N_PRIMARY_CANCER_SITES, .data$STUDY_DESIGN_PRIMARY_PURPOSE))
 
     if (nrow(pcg_report_trials[["trials"]]) > 2000) {


### PR DESCRIPTION
Running PCGR 1.0.2 in no_docker mode (in Ubuntu in WSL, if that matters), I got this error:

```
2022-04-10 23:27:20 - pcgr-report-generation - INFO - Tumor primary site: Uterus
2022-04-10 23:27:20 - pcgr-report-generation - INFO - Initializing PCGR report - sample EC_0051_E-EC_0051_T
2022-04-10 23:27:20 - pcgr-report-generation - INFO - ------
Error in `dplyr::arrange()`:
! `desc()` must be called with exactly one argument.
Backtrace:
     ▆
  1. ├─pcgrr::generate_pcgr_report(...)
  2. │ └─pcgrr::generate_report_data_trials(...)
  3. │   └─... %>% ...
  4. ├─dplyr::select(., -c(.data$N_PRIMARY_CANCER_SITES, .data$STUDY_DESIGN_PRIMARY_PURPOSE))
  5. ├─dplyr::arrange(...)
  6. └─dplyr:::arrange.data.frame(...)
  7.   └─dplyr:::arrange_rows(.data, dots)
  8.     └─dplyr:::map(...)
  9.       └─base::lapply(.x, .f, ...)
 10.         └─dplyr FUN(X[[i]], ...)
 11.           └─rlang::abort(...)
Execution halted
```

This diff seems to fix it - I compiled a binary package in rstudio with this change and extracted that package into the conda pcgrr installation. Rerunning the same pcgr command (after deleting the output directory) worked afterwards.