### PR TITLE
Minor refactor

### DIFF
--- a/pcgr/arg_checker.py
+++ b/pcgr/arg_checker.py
@@ -13,10 +13,6 @@ def check_args(arg_dict):
         err_msg = f"Required argument '--pcgr_dir' does not exist ({arg_dict['pcgr_dir']})."
         error_message(err_msg, logger)
 
-    if arg_dict['output_dir'] is None or not os.path.exists(arg_dict['output_dir']):
-        err_msg = f"Required argument '--output_dir' does not exist ({arg_dict['output_dir']})."
-        error_message(err_msg, logger)
-
     if arg_dict['genome_assembly'] is None:
         err_msg = f"Required argument '--genome_assembly' has no/undefined value ({arg_dict['genome_assembly']})."
         error_message(err_msg, logger)
@@ -223,11 +219,8 @@ def verify_input_files(arg_dict):
         err_msg = 'Please specifiy either a VCF input file (--input_vcf) or a copy number segment file (--input_cna)'
         error_message(err_msg, logger)
 
-    # check the existence of given output folder
-    output_dir_full = os.path.abspath(arg_dict['output_dir'])
-    if not os.path.isdir(output_dir_full):
-        err_msg = f'Output directory ({output_dir_full}) does not exist'
-        error_message(err_msg, logger)
+    # create output folder (if not already exists)
+    output_dir_full = safe_makedir(os.path.abspath(arg_dict['output_dir']))
 
     # check if panel of normal VCF exist
     if not arg_dict["pon_vcf"] is None:
@@ -441,10 +434,6 @@ def check_args_cpsr(arg_dict):
     if arg_dict['pcgr_dir'] is None or not os.path.exists(arg_dict['pcgr_dir']):
         err_msg = f"Required argument '--pcgr_dir' does not exist ({arg_dict['pcgr_dir']})."
         error_message(err_msg,logger)
-    ## Check that output directory is provided and exists
-    if arg_dict['output_dir'] is None or not os.path.exists(arg_dict['output_dir']):
-        err_msg = f"Required argument '--output_dir' does not exist ({arg_dict['output_dir']})."
-        error_message(err_msg,logger)
     ## Check that genome assembly is set
     if arg_dict['genome_assembly'] is None:
         err_msg = f"Required argument '--genome_assembly' has no/undefined value ({arg_dict['genome_assembly']})."
@@ -538,11 +527,8 @@ def verify_input_files_cpsr(arg_dict):
     input_customlist_basename = "NA"
     input_customlist_dir = "NA"
 
-    ## check the existence of given output folder
-    output_dir_full = os.path.abspath(arg_dict['output_dir'])
-    if not os.path.isdir(output_dir_full):
-        err_msg = f"Output directory ({output_dir_full}) does not exist"
-        error_message(err_msg,logger)
+    # create output folder (if not already exists)
+    output_dir_full = safe_makedir(os.path.abspath(arg_dict['output_dir']))
 
     ## check if input BED exist
     if not arg_dict['custom_list'] is None:

--- a/pcgr/arg_checker.py
+++ b/pcgr/arg_checker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from pcgr import pcgr_vars
+from pcgr import pcgr_vars, utils
 from pcgr.utils import getlogger, error_message, warn_message
 import os
 
@@ -220,7 +220,7 @@ def verify_input_files(arg_dict):
         error_message(err_msg, logger)
 
     # create output folder (if not already exists)
-    output_dir_full = safe_makedir(os.path.abspath(arg_dict['output_dir']))
+    output_dir_full = utils.safe_makedir(os.path.abspath(arg_dict['output_dir']))
 
     # check if panel of normal VCF exist
     if not arg_dict["pon_vcf"] is None:
@@ -528,7 +528,7 @@ def verify_input_files_cpsr(arg_dict):
     input_customlist_dir = "NA"
 
     # create output folder (if not already exists)
-    output_dir_full = safe_makedir(os.path.abspath(arg_dict['output_dir']))
+    output_dir_full = utils.safe_makedir(os.path.abspath(arg_dict['output_dir']))
 
     ## check if input BED exist
     if not arg_dict['custom_list'] is None:

--- a/pcgr/config.py
+++ b/pcgr/config.py
@@ -5,6 +5,9 @@ from pcgr import pcgr_vars
 
 def create_config(arg_dict):
     config_options = {
+      'sample_id': arg_dict['sample_id'],
+      'genome_assembly': arg_dict['genome_assembly'],
+      'debug': arg_dict['debug'],
       'tumor_purity': 'NA',
       'tumor_ploidy': 'NA',
       'tumor_type': {

--- a/pcgr/utils.py
+++ b/pcgr/utils.py
@@ -4,6 +4,7 @@ import subprocess
 import shutil
 import logging
 import os
+import time
 import errno
 import platform
 
@@ -107,3 +108,24 @@ def remove(filename):
     except OSError as e:
         if e.errno != errno.ENOENT: # errno.ENOENT = no such file or directory
             raise # re-raise exception if a different error occurred
+
+
+# from https://github.com/bcbio/bcbio-nextgen/blob/master/bcbio/utils.py
+def safe_makedir(dname):
+    """Make a directory if it does not exist, handling concurrent race conditions.
+    """
+    if not dname:
+        return dname
+    num_tries = 0
+    max_tries = 5
+    while not os.path.exists(dname):
+        # we could get an error here if multiple processes are creating
+        # the directory at the same time. Grr, concurrency.
+        try:
+            os.makedirs(dname)
+        except OSError:
+            if num_tries > max_tries:
+                raise
+            num_tries += 1
+            time.sleep(2)
+    return dname

--- a/pcgr/utils.py
+++ b/pcgr/utils.py
@@ -4,6 +4,7 @@ import subprocess
 import shutil
 import logging
 import os
+import errno
 import platform
 
 
@@ -98,3 +99,11 @@ def get_cpsr_version():
     rscript = script_path("pcgrr", "bin/Rscript")
     v_cmd = f"{rscript} -e 'x <- paste0(\"cpsr \", as.character(packageVersion(\"cpsr\"))); cat(x, \"\n\")'"
     return subprocess.check_output(v_cmd, shell=True).decode("utf-8")
+
+# https://stackoverflow.com/a/10840586/2169986
+def remove(filename):
+    try:
+        os.remove(filename)
+    except OSError as e:
+        if e.errno != errno.ENOENT: # errno.ENOENT = no such file or directory
+            raise # re-raise exception if a different error occurred

--- a/scripts/pcgr_summarise.py
+++ b/scripts/pcgr_summarise.py
@@ -27,7 +27,7 @@ def __main__():
 
     extend_vcf_annotations(args.vcf_file, args.pcgr_db_dir, logger, args.pon_annotation, args.regulatory_annotation, args.cpsr, args.debug)
 
-def extend_vcf_annotations(query_vcf, pcgr_db_directory, logger, pon_annotation, regulatory_annotation, cpsr, debug):
+def extend_vcf_annotations(query_vcf, pcgr_db_dir, logger, pon_annotation, regulatory_annotation, cpsr, debug):
     """
     Function that reads VEP/vcfanno-annotated VCF and extends the VCF INFO column with tags from
     1. CSQ elements within the primary transcript consequence picked by VEP, e.g. SYMBOL, Feature, Gene, Consequence etc.
@@ -36,14 +36,14 @@ def extend_vcf_annotations(query_vcf, pcgr_db_directory, logger, pon_annotation,
     4. Variant effect predictions
     5. Panel-of-normal (blacklisted variants) annotation
 
-    List of INFO tags to be produced is provided by the 'infotags' files in the pcgr_db_directory
+    List of INFO tags to be produced is provided by the 'infotags' files in the pcgr_db_dir
     """
 
     ## read VEP and PCGR tags to be appended to VCF file
-    vcf_infotags_meta = annoutils.read_infotag_file(os.path.join(pcgr_db_directory, 'pcgr_infotags.tsv'))
+    vcf_infotags_meta = annoutils.read_infotag_file(os.path.join(pcgr_db_dir, 'pcgr_infotags.tsv'))
     if cpsr is True:
-        vcf_infotags_meta = annoutils.read_infotag_file(os.path.join(pcgr_db_directory, 'cpsr_infotags.tsv'))
-    pcgr_onco_xref_map = annoutils.read_genexref_namemap(os.path.join(pcgr_db_directory, 'pcgr_onco_xref', 'pcgr_onco_xref_namemap.tsv'))
+        vcf_infotags_meta = annoutils.read_infotag_file(os.path.join(pcgr_db_dir, 'cpsr_infotags.tsv'))
+    pcgr_onco_xref_map = annoutils.read_genexref_namemap(os.path.join(pcgr_db_dir, 'pcgr_onco_xref', 'pcgr_onco_xref_namemap.tsv'))
 
 
     out_vcf = re.sub(r'\.vcf(\.gz){0,}$','.annotated.vcf',query_vcf)

--- a/scripts/pcgr_validate_input.py
+++ b/scripts/pcgr_validate_input.py
@@ -408,10 +408,10 @@ def simplify_vcf(input_vcf, vcf, output_dir, keep_uncompressed, logger, debug):
         command_decompose = f'vt decompose -s {input_vcf_pcgr_ready} > {input_vcf_pcgr_ready_decomposed} 2> {os.path.join(output_dir, "decompose.log")}'
         check_subprocess(logger, command_decompose, debug)
     else:
-        logger.info('All sites seem to be decomposed, so skipping decompostion')
+        logger.info('All sites seem to be decomposed - skipping decomposition!')
         check_subprocess(logger, f'cp {input_vcf_pcgr_ready} {input_vcf_pcgr_ready_decomposed}', debug)
 
-    # need to keep uncompressed copy for vcf2maf.pl
+    # need to keep uncompressed copy for vcf2maf.pl if selected
     bgzip_cmd = f"bgzip -cf {input_vcf_pcgr_ready_decomposed} > {input_vcf_pcgr_ready_decomposed}.gz" if keep_uncompressed else f"bgzip -f {input_vcf_pcgr_ready_decomposed}"
     check_subprocess(logger, bgzip_cmd, debug)
     check_subprocess(logger, f'tabix -p vcf {input_vcf_pcgr_ready_decomposed}.gz', debug)
@@ -427,7 +427,6 @@ def simplify_vcf(input_vcf, vcf, output_dir, keep_uncompressed, logger, debug):
             logger.info('')
             exit(1)
 
-    print(input_vcf_pcgr_ready)
     utils.remove(input_vcf_pcgr_ready)
     utils.remove(os.path.join(output_dir, "decompose.log"))
 

--- a/scripts/pcgr_vcfanno.py
+++ b/scripts/pcgr_vcfanno.py
@@ -4,6 +4,7 @@ import argparse
 import cyvcf2
 import random
 import re
+import glob
 from pcgr import utils
 from pcgr.utils import check_subprocess
 
@@ -162,10 +163,11 @@ def run_vcfanno(num_processes, query_vcf, panel_normal_vcf, query_info_tags, vcf
 
     check_subprocess(logger, f'cat {vcfheader_file} > {output_vcf}', debug=False)
     check_subprocess(logger, f'cat {out_vcf_vcfanno_unsorted1} | grep -v \'^#\' >> {output_vcf}', debug=False)
-    if not keep_logs is True:
-        check_subprocess(logger, f'rm -f {output_vcf}.tmp*', debug=False)
-    check_subprocess(logger, f'bgzip -f {output_vcf}', debug=False)
-    check_subprocess(logger, f'tabix -f -p vcf {output_vcf}.gz', debug=False)
+    check_subprocess(logger, f'bgzip -f {output_vcf}', debug)
+    check_subprocess(logger, f'tabix -f -p vcf {output_vcf}.gz', debug)
+    if not keep_logs:
+        for tmpf in glob.glob(f"{output_vcf}.tmp*"):
+            utils.remove(tmpf)
 
 def append_to_vcf_header(pcgr_db_directory, datasource, vcfheader_file, logger):
     """


### PR DESCRIPTION
A bit of code cleanup/refactor. 
- using python's native `os.remove` and `os.rename` for glob cleanup
- using `config_options` (instead of parts of `arg_dict`) throughout the main script
- creating output directory if it doesn't already exist (does not error out now).
- keep decompressed VCF only if vcf2maf option is specified (regardless if debug is specified or not)