### PR TITLE
fix for CLI argument "cna_overlap_pct"

### DIFF
--- a/pcgrr/R/main.R
+++ b/pcgrr/R/main.R
@@ -996,6 +996,7 @@ generate_report_data_cna <-
     onco_ts_sets <-
       get_oncogene_tsgene_target_sets(
         cna_transcript_df,
+        transcript_overlap_pct = transcript_overlap_pct,
         log_r_homdel = log_r_homdel,
         log_r_gain = log_r_gain,
         tumor_type = tumor_type,


### PR DESCRIPTION
The CLI argument `--cna_overlap_pct` should at default be at 50%.

However, the CLI argument is not passed to the function `get_oncogene_tsgene_target_sets` that actually does the filtering resulting in the functions default of 100%. Therefore the argument will also be ineffective if set explicitly in the CLI.

This should be fixed by this pull request.

Also; Thanks for the great tool.