### PR TITLE
Update changelog with v1.1.0 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Personal Cancer Genome Reporter (PCGR) is a stand-alone software package for
 PCGR interprets primarily **somatic SNVs/InDels and copy number aberrations**. The software extends basic gene and variant annotations from the [Ensembl's Variant Effect Predictor (VEP)](http://www.ensembl.org/info/docs/tools/vep/index.html) with oncology-relevant, up-to-date annotations retrieved flexibly through [vcfanno](https://github.com/brentp/vcfanno), and produces interactive HTML reports intended for clinical interpretation. PCGR can perform multiple types of analyses, including:
 
 - Somatic variant classification (ACMG/AMP)
-	- mapping the therapeutic and prognostic implications of somatic DNA aberrations
+  - mapping the therapeutic and prognostic implications of somatic DNA aberrations
 - Tumor mutational burden (TMB) estimation
 - Tumor-only analysis (variant filtering)
 - Mutational signature analysis
@@ -20,14 +20,25 @@ If you want to interrogate germline variants and their relation to cancer predis
 
 ### News
 
+-   *October 2022*: **1.1.0 release**
+
+    - Remove Docker command wrappers
+    - Deprecate `--no_docker` and `--docker_uid` CLI options
+    - Merged PRs
+      [pr192](https://github.com/sigven/pcgr/pull/192),
+      [pr193](https://github.com/sigven/pcgr/pull/193),
+      [pr194](https://github.com/sigven/pcgr/pull/194),
+      [pr196](https://github.com/sigven/pcgr/pull/196).
+    - See [CHANGELOG](http://sigven.github.io/pcgr/articles/CHANGELOG.html) for a few more changes.
+
 -   *May 2022*: **1.0.3 release**
 
     - Merged [PR #191](https://github.com/sigven/pcgr/pull/191)
-    
+
 -   *March 2022*: **1.0.2 release**
-    
+
     - Fixed [CPSR issue #44](https://github.com/sigven/cpsr/issues/44)
-    
+
 -   *March 2022*: **1.0.1 release**
 
     -   Fixed bug for huge input sets that cause JSON output crash

--- a/pcgrr/vignettes/CHANGELOG.Rmd
+++ b/pcgrr/vignettes/CHANGELOG.Rmd
@@ -3,6 +3,32 @@ title: "Changelog"
 output: rmarkdown::html_document
 ---
 
+## v1.1.0
+
+- Date: **2022-10-XX**
+- [Diff between v1.1.0 and v1.0.3](https://github.com/sigven/pcgr/compare/v1.0.3...v1.1.0)
+
+### Changes
+
+- Remove Docker command wrappers (note: this does not remove the Docker _functionality_ from PCGR; instead
+  it removes the legacy wrappers that were created in the original PCGR version). This along with a lot of
+  other general changes are summarised in [pr193](https://github.com/sigven/pcgr/pull/193). Of note:
+  - `--no_docker` and `--docker_uid` CLI arguments are now obsolete.
+  - `--version` CLI argument added for `pcgr/cpsr.py`
+  - declutter repetitive log messages
+  - refactor `pcgr/cpsr.py` script
+- Update documentation and declutter logging; refactor dict creation ([pr192](https://github.com/sigven/pcgr/pull/192))
+- Minor refactor ([pr194](https://github.com/sigven/pcgr/pull/194)):
+  - switch to using Python's native `os.remove` and `os.rename` for glob cleanup
+  - keep decompressed VCF only if `--vcf2maf` option is specified.
+    The [vcf2maf](https://github.com/mskcc/vcf2maf) tool does not support compressed VCFs - see
+    [issue235](https://github.com/mskcc/vcf2maf/issues/235).
+- Fix for CLI argument `--cna_overlap_pct` ([pr196](https://github.com/sigven/pcgr/pull/196).
+
+### New Contributors
+
+- [@niklasmueboe](https://github.com/niklasmueboe) ([pr196](https://github.com/sigven/pcgr/pull/196).
+
 ## v1.0.3
 
  * Date: **2022-05-24**
@@ -12,7 +38,7 @@ output: rmarkdown::html_document
  * Bug in clinical trials sorting, [#191](https://github.com/sigven/pcgr/pull/191)
 
 ## v1.0.2
- 
+
  * Date: **2022-03-30**
 
 ##### Fixed
@@ -24,11 +50,11 @@ output: rmarkdown::html_document
  * Date: **2022-03-09**
 
 ##### Fixed
- 
- * Writing to JSON crashes when size of input VCF is huge (variants in the order of millions). If raw input set (VCF) contains > 500,000 variants, this set will, prior to reporting, be reduced by 
+
+ * Writing to JSON crashes when size of input VCF is huge (variants in the order of millions). If raw input set (VCF) contains > 500,000 variants, this set will, prior to reporting, be reduced by
       * A) exclusion of intergenic and intronic variants, and
       * B) exclusion of upstream_gene/downstream_gene variants (if variant set is still above 500,000 after step A)
- * [Bug in signature analysis](https://github.com/sigven/pcgr/issues/187) for cases where the input variant set fits to > 18 different aetiologies. 
+ * [Bug in signature analysis](https://github.com/sigven/pcgr/issues/187) for cases where the input variant set fits to > 18 different aetiologies.
 
 ## v1.0.0
 
@@ -47,7 +73,7 @@ output: rmarkdown::html_document
 
 * Complete restructure of Python and R components.Installation now relies on two separate [conda](https://docs.conda.io/en/latest/) packages, `pcgr` (Python component) and `pcgrr` (R component). Direct Docker support remains, with the Dockerfile simplified to rely exclusively on the installation of the above Conda packages.
 
-##### Removed 
+##### Removed
 
 * VCF validation step. Feedback from users suggested that Ensembl's `vcf-validator` was often too stringent so its use has been deprecated. The `--no_vcf_validate` option remains for backwards compatibility.
 
@@ -121,8 +147,8 @@ output: rmarkdown::html_document
 
  * Date: **2020-11-30**
 
- * Data updates: 
-   * ClinVar, 
+ * Data updates:
+   * ClinVar,
    * GWAS catalog
    * CIViC
    * CancerMine
@@ -187,7 +213,7 @@ output: rmarkdown::html_document
  * References are updated and all provided with DOI
 
 ## v0.8.4
- 
+
  * Date: **2019-11-18**
 
  - Data updates: ClinVar, CIViC, CancerMine, UniProt KB
@@ -237,7 +263,7 @@ output: rmarkdown::html_document
 ##### Added
   * *Cancer_NOS.toml* as configuration file for unspecified tumor types
 
-## v0.8.0 
+## v0.8.0
 
  * Date: **2019-05-20**
 
@@ -297,7 +323,7 @@ output: rmarkdown::html_document
 
 
 ## v0.7.0
- 
+
  * Date: **2018-11-27**
 
 ##### Fixed
@@ -368,7 +394,7 @@ output: rmarkdown::html_document
 ## v0.6.1
 
  * Date: **2018-05-02**
- 
+
 ##### Fixed
  * Bug in tier assignment 'pcgr_acmg' (case for no variants in tier1,2,3)
  * Bug in tier assignment 'pcgr_acmg' (no tumor type specified, evidence items with weak support detected)

--- a/pcgrr/vignettes/installation.Rmd
+++ b/pcgrr/vignettes/installation.Rmd
@@ -5,9 +5,11 @@ output: rmarkdown::html_document
 
 ## Quick Installation
 
-If you know what [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html)
-is, you only need to run the following commands in order to install the PCGR
-software requirements:
+### Conda
+
+- If you know what [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html)
+  is, you only need to run the following commands in order to install the PCGR
+  software requirements:
 
 ```bash
 PCGR_VERSION="1.0.3"
@@ -27,7 +29,14 @@ conda activate ./pcgr
 pcgr --version
 ```
 
-For downloading the data bundle, see [STEP 1](#step1) further below.
+### Data
+
+- For downloading the data bundle, see [STEP 1](#step1) further below.
+
+### Docker
+
+- If you know what [Docker](https://www.docker.com/) is, instead of using the above conda method
+  you can jump straight to the [PCGR Docker setup](#dockersetup) section.
 
 ## Detailed Installation
 
@@ -206,30 +215,13 @@ versions of Docker/Windows do not work with PCGR (an example being [mounting of 
 - Pull the [PCGR Docker image](https://hub.docker.com/r/sigven/pcgr/tags) from
   DockerHub (approx 5.7Gb) with: `docker pull sigven/pcgr:vX.X.X`
 
-#### c) Run PCGR Docker Container directly (_recommended_) or indirectly
+#### c) Run PCGR Docker Container
 
-This next step depends on how familiar you are with working with Docker volumes
-(<https://docs.docker.com/storage/volumes/>).
+If you are familiar with working with Docker volumes (<https://docs.docker.com/storage/volumes/>)
+you can run PCGR using Docker instead of conda using the `-v <host>:<container>` Docker option.
+You'll need to map your PCGR inputs to Docker container paths.
 
-- If you know how to use the `-v <host>:<container>` Docker option, you can
-  use the PCGR Docker image directly, which would not involve
-  having to set up a Python environment.
-  Jump to the [PCGR Docker direct setup](#dockerdirectsetup) for more details.
-- Alternatively, you can allow PCGR itself to handle the Docker volume setup
-  intricacies, but this requires a Python environment setup (which can be a bit
-  cumbersome if you're not too familiar with conda or virtualenv).
-  Jump to the [PCGR Docker indirect setup](#dockerindirectsetup) for more details.
-
-<a name="dockerdirectsetup"></a>
-
-##### Directly
-
-<details>
-
-<summary>CLICK ME!</summary>
-
-You'll need to map your PCGR inputs to Docker container paths. For example, say
-you have the input VCF `sampleX.vcf.gz` stored in the
+For example, say you have the input VCF `sampleX.vcf.gz` stored in the
 directory `/Users/you/project1`. You would need to supply Docker with a
 `--volume` (or `-v`) option mapping the directory of that VCF with
 a directory inside the Docker container, e.g. `/home/input_vcf_dir`.
@@ -251,71 +243,8 @@ docker container run -it --rm \
       --genome_assembly "grch38" \
       --sample_id "SampleB" \
       --assay "WGS" \
-      --vcf2maf \
-      --no_docker
+      --vcf2maf
 ```
 
-- Note the `--no_docker` option in the above command. Since you're running that
-  command _directly_ inside the container, you need to use that option to bypass
-  the _indirect_ Docker PCGR run.
-- Also note the path mappings. You're using the _container_ paths in the
+- Note the path mappings. You're using the _container_ paths in the
   command, not the _host_ (your machine's) paths.
-
-</details>
-
-<a name="dockerindirectsetup"></a>
-
-##### Indirectly (not recommended)
-
-<details>
-
-<summary>CLICK ME!</summary>
-
-Install the PCGR Python component on your local machine. Only requirement is
-Python > 3.6. We would _strongly_ advise to install it in a virtual Python
-environment with conda (or virtualenv) (read the previous sections for how to
-install conda). Or else it will (probably) use your
-system's default Python and you'll end up in a situation like <https://xkcd.com/1987/>.
-Here's an example using conda/mamba, with only Python 3.7 as a dependency:
-
-```bash
-(base) $ mamba create -n pcgr_docker_env -c conda-forge python=3.7
-(base) $ conda activate pcgr_docker_env
-
-(pcgr_docker_env) $ which python
-/Users/you/miniconda3/envs/pcgr_docker_env/bin/python
-(pcgr_docker_env) $ cd /Users/you/dir4/PCGR
-
-(pcgr_docker_env) $ pip install -e .
-Obtaining file:///Users/you/dir4/PCGR
-  Preparing metadata (setup.py) ... done
-Installing collected packages: pcgr
-  Running setup.py develop for pcgr
-Successfully installed pcgr-X.X.X
-
-(pcgr_docker_env) $ which pcgr
-/Users/you/miniconda3/envs/pcgr_docker/bin/pcgr
-(pcgr_docker_env) $ pcgr --version
-pcgr X.X.X
-```
-
-You should now be all set up to run PCGR from within that `pcgr_docker_env`
-conda environment! Here's an example command:
-
-```bash
-(pcgr_docker_env) $ pcgr \
-  --input_vcf "/Users/you/dir1/tumor_sample.BRCA.vcf.gz" \
-  --pcgr_dir "/Users/you/dir2/data" \
-  --output_dir "/Users/you/dir3/pcgr_outputs" \
-  --genome_assembly "grch38" \
-  --sample_id "SampleB" \
-  --assay "WGS"
-```
-
-- Note that we do not specify the `--no_docker` option. PCGR will
-  automatically look for the more recent Docker container on your
-  machine, and then run the above command inside it _indirectly_.
-- Also note the path mappings. You're using the actual _host_ (your machine's)
-  paths, not the _container_ paths.
-
-</details>


### PR DESCRIPTION
Summarised the changes since the v1.0.3 release in preparation for the v1.1.0 update. See <https://github.com/sigven/pcgr/compare/v1.0.3...master>. Also adjusted the installation doc since we're deprecating the docker wrapper workaround.