### PR TITLE
Use bcftools for initial VCF parsing

### DIFF
--- a/conda/env/yml/pcgr.yml
+++ b/conda/env/yml/pcgr.yml
@@ -9,6 +9,7 @@ channels:
 dependencies:
   - pcgr ==1.1.0 # versioned by bump2version
   - bedtools ==2.30.0
+  - bcftools ==1.10.2
   - cyvcf2 ==0.30.11
   - ensembl-vep ==105.0
   - htslib ==1.10.2

--- a/pcgr/config.py
+++ b/pcgr/config.py
@@ -8,6 +8,7 @@ def create_config(arg_dict):
       'sample_id': arg_dict['sample_id'],
       'genome_assembly': arg_dict['genome_assembly'],
       'debug': arg_dict['debug'],
+      'pcgrr_conda': arg_dict['pcgrr_conda'],
       'tumor_purity': 'NA',
       'tumor_ploidy': 'NA',
       'tumor_type': {

--- a/pcgr/main.py
+++ b/pcgr/main.py
@@ -15,14 +15,14 @@ from argparse import RawTextHelpFormatter
 
 def cli():
 
-    program_description = (f'Personal Cancer Genome Reporter (PCGR) workflow for clinical interpretation of '
-                           f'somatic nucleotide variants and copy number aberration segments')
+    program_description = (f"Personal Cancer Genome Reporter (PCGR) workflow for clinical interpretation of "
+                           f"somatic nucleotide variants and copy number aberration segments")
     program_options = "\n\t--input_vcf <INPUT_VCF>\n\t--pcgr_dir <PCGR_DIR>\n\t--output_dir <OUTPUT_DIR>\n\t--genome_assembly" + \
     " <GENOME_ASSEMBLY>\n\t--sample_id <SAMPLE_ID>"
 
     parser = argparse.ArgumentParser(description=program_description,
                                      formatter_class=RawTextHelpFormatter,
-                                     usage=f'\n\t%(prog)s -h [options] {program_options} \n\n')
+                                     usage=f"\n\t%(prog)s -h [options] {program_options} \n\n")
     parser._action_groups.pop()
     required = parser.add_argument_group("Required arguments")
     # optional_rna = parser.add_argument_group("Bulk RNA-seq and RNA fusion options")
@@ -63,8 +63,8 @@ def cli():
     optional_signatures.add_argument("--estimate_signatures", action="store_true", help="Estimate relative contributions of reference mutational signatures in query sample and detect potential kataegis events, default: %(default)s")
     optional_signatures.add_argument("--min_mutations_signatures", type=int, default=200, dest="min_mutations_signatures", help="Minimum number of SNVs required for reconstruction of mutational signatures (SBS) by MutationalPatterns (default: %(default)s, minimum n = 100)")
     optional_signatures.add_argument("--all_reference_signatures", action="store_true", help="Use all reference mutational signatures (SBS, n = 67) in signature reconstruction rather than only those already attributed to the tumor type (default: %(default)s)")
-    optional_signatures.add_argument('--include_artefact_signatures', action="store_true", help="Include sequencing artefacts in the collection of reference signatures (default: %(default)s")
-    optional_signatures.add_argument('--prevalence_reference_signatures', type=int, default=5, choices=[1,2,5,10,15,20], help="Minimum tumor-type prevalence (in percent) of reference signatures to be included in refitting procedure (default: %(default)s)")
+    optional_signatures.add_argument("--include_artefact_signatures", action="store_true", help="Include sequencing artefacts in the collection of reference signatures (default: %(default)s")
+    optional_signatures.add_argument("--prevalence_reference_signatures", type=int, default=5, choices=[1,2,5,10,15,20], help="Minimum tumor-type prevalence (in percent) of reference signatures to be included in refitting procedure (default: %(default)s)")
 
     optional_other.add_argument("--cpsr_report", dest="cpsr_report", help="CPSR report file (Gzipped JSON - file ending with 'cpsr.<genome_assembly>.json.gz' -  germline report of patient's blood/control sample")
     optional_other.add_argument("--vcf2maf", action="store_true", help="Generate a MAF file for input VCF using https://github.com/mskcc/vcf2maf (default: %(default)s)")
@@ -72,13 +72,14 @@ def cli():
     optional_other.add_argument("--assay", dest="assay", choices=["WES", "WGS", "TARGETED"], default="WES", help="Type of DNA sequencing assay performed for input data (VCF) default: %(default)s")
     optional_other.add_argument("--include_trials", action="store_true", help="(Beta) Include relevant ongoing or future clinical trials, focusing on studies with molecularly targeted interventions")
     optional_other.add_argument("--preserved_info_tags", dest="preserved_info_tags", default="None", help="Comma-separated string of VCF INFO tags from query VCF that should be kept in PCGR output TSV file")
-    optional_other.add_argument("--report_theme", choices=["default", "cerulean", "journal", "flatly", "readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone", "simplex", "yeti"], help="Visual report theme (rmarkdown)", default='default')
-    optional_other.add_argument('--report_nonfloating_toc', action='store_true', help='Do not float the table of contents (TOC) in output report (rmarkdown), default: %(default)s')
+    optional_other.add_argument("--report_theme", choices=["default", "cerulean", "journal", "flatly", "readable", "spacelab", "united", "cosmo", "lumen", "paper", "sandstone", "simplex", "yeti"], help="Visual report theme (rmarkdown)", default="default")
+    optional_other.add_argument("--report_nonfloating_toc", action="store_true", help="Do not float the table of contents (TOC) in output report (rmarkdown), default: %(default)s")
     optional_other.add_argument("--force_overwrite", action="store_true", help="By default, the script will fail with an error if any output file already exists. You can force the overwrite of existing result files by using this flag, default: %(default)s")
     optional_other.add_argument("--version", action="version", version="%(prog)s " + str(pcgr_vars.PCGR_VERSION))
     optional_other.add_argument("--basic", action="store_true", help="Run functional variant annotation on VCF through VEP/vcfanno, omit other analyses (i.e. Tier assignment/MSI/TMB/Signatures etc. and report generation (STEP 4), default: %(default)s")
     optional_other.add_argument("--no_vcf_validate", action="store_true", help="Skip validation of input VCF with Ensembl's vcf-validator, default: %(default)s")
     optional_other.add_argument("--debug", action="store_true", help="Print full commands to log")
+    optional_other.add_argument("--pcgrr_conda", default="pcgrr", help="pcgrr conda env name (default: %(default)s)")
 
     optional_vcfanno.add_argument("--vcfanno_n_proc", default=4, type=int, help="Number of vcfanno processes (option '-p' in vcfanno), default: %(default)s")
     optional_vep.add_argument("--vep_n_forks", default=4, type=int, help="Number of forks (option '--fork' in VEP), default: %(default)s")
@@ -86,7 +87,7 @@ def cli():
     optional_vep.add_argument("--vep_pick_order", default="canonical,appris,biotype,ccds,rank,tsl,length,mane", help=f"Comma-separated string of ordered transcript/variant properties for selection of primary variant consequence\n(option '--pick_order' in VEP), default: %(default)s")
     optional_vep.add_argument("--vep_no_intergenic", action="store_true", help="Skip intergenic variants during processing (option '--no_intergenic' in VEP), default: %(default)s")
     optional_vep.add_argument("--vep_regulatory", action="store_true", help="Add VEP regulatory annotations (option '--regulatory') or non-coding interpretation, default: %(default)s")
-    optional_vep.add_argument('--vep_gencode_all', action='store_true', help = "Consider all GENCODE transcripts with Variant Effect Predictor (VEP) (option '--gencode_basic' in VEP is used by default in PCGR).")
+    optional_vep.add_argument("--vep_gencode_all", action="store_true", help = "Consider all GENCODE transcripts with Variant Effect Predictor (VEP) (option '--gencode_basic' in VEP is used by default in PCGR).")
 
 
     optional_tumor_only.add_argument("--tumor_only", action="store_true", help="Input VCF comes from tumor-only sequencing, calls will be filtered for variants of germline origin, (default: %(default)s)")
@@ -431,7 +432,8 @@ def run_pcgr(pcgr_paths, config_options):
         logger.info('PCGR - STEP 4: Generation of output files - variant interpretation report for precision oncology')
 
         # export PATH to R conda env Rscript
-        rscript = utils.script_path('pcgrr', 'bin/Rscript')
+        pcgrr_conda = config_options['pcgrr_conda']
+        rscript = utils.script_path(pcgrr_conda, 'bin/Rscript')
         pcgrr_script = utils.script_path('pcgr', 'bin/pcgrr.R')
         pcgr_report_command = (
                 f"{rscript} {pcgrr_script} "

--- a/pcgr/main.py
+++ b/pcgr/main.py
@@ -41,8 +41,8 @@ def cli():
     optional_other.add_argument("--logr_gain", type=float, default=0.8, dest="logr_gain", help="Log ratio-threshold (minimum) for segments containing copy number gains/amplifications (default: %(default)s)")
     optional_other.add_argument("--logr_homdel", type=float, default=-0.8, dest="logr_homdel", help="Log ratio-threshold (maximum) for segments containing homozygous deletions (default: %(default)s)")
     optional_other.add_argument("--cna_overlap_pct", type=float, default=50, dest="cna_overlap_pct", help="Mean percent overlap between copy number segment and gene transcripts for reporting of gains/losses in tumor suppressor genes/oncogenes, (default: %(default)s)")
-    optional_other.add_argument("--tumor_site", dest="tsite", type=int, default=0, help="Optional integer code to specify primary tumor type/site of query sample,\n choose any of the following identifiers:\n" + str(pcgr_vars.tumor_sites) + "\n(default: %(default)s - any tumor type)")
-    optional_other.add_argument("--tumor_purity", type=float, dest="tumor_purity", help="Estimated tumor purity (between 0 and 1, (default: %(default)s)")
+    optional_other.add_argument("--tumor_site", dest="tsite", type=int, default=0, help="Optional integer code to specify primary tumor type/site of query sample,\nchoose any of the following identifiers:\n" + str(pcgr_vars.tumor_sites) + "\n(default: %(default)s - any tumor type)")
+    optional_other.add_argument("--tumor_purity", type=float, dest="tumor_purity", help="Estimated tumor purity (between 0 and 1) (default: %(default)s)")
     optional_other.add_argument("--tumor_ploidy", type=float, dest="tumor_ploidy", help="Estimated tumor ploidy (default: %(default)s)")
 
     optional_allelic_support.add_argument("--tumor_dp_tag", dest="tumor_dp_tag", default="_NA_", help="Specify VCF INFO tag for sequencing depth (tumor, must be Type=Integer, default: %(default)s")
@@ -85,7 +85,7 @@ def cli():
     optional_vep.add_argument("--vep_buffer_size", default=100, type=int, help=f"Variant buffer size (variants read into memory simultaneously, option '--buffer_size' in VEP)\n- set lower to reduce memory usage, default: %(default)s")
     optional_vep.add_argument("--vep_pick_order", default="canonical,appris,biotype,ccds,rank,tsl,length,mane", help=f"Comma-separated string of ordered transcript/variant properties for selection of primary variant consequence\n(option '--pick_order' in VEP), default: %(default)s")
     optional_vep.add_argument("--vep_no_intergenic", action="store_true", help="Skip intergenic variants during processing (option '--no_intergenic' in VEP), default: %(default)s")
-    optional_vep.add_argument("--vep_regulatory", action="store_true", help="Add VEP regulatory annotations (option '--regulatory' )or non-coding interpretation, default: %(default)s")
+    optional_vep.add_argument("--vep_regulatory", action="store_true", help="Add VEP regulatory annotations (option '--regulatory') or non-coding interpretation, default: %(default)s")
     optional_vep.add_argument('--vep_gencode_all', action='store_true', help = "Consider all GENCODE transcripts with Variant Effect Predictor (VEP) (option '--gencode_basic' in VEP is used by default in PCGR).")
 
 

--- a/pcgrr/vignettes/CHANGELOG.Rmd
+++ b/pcgrr/vignettes/CHANGELOG.Rmd
@@ -3,9 +3,19 @@ title: "Changelog"
 output: rmarkdown::html_document
 ---
 
+## v1.2.0-rc
+
+- Date: **2022-11-XX**
+- [Diff between v1.2.0 and v1.1.0](https://github.com/sigven/pcgr/compare/v1.1.0...v1.2.0)
+
+### Changes
+
+- Keep only autosomal, X, Y, M/MT chromosomes
+- Import bcftools as dependency
+
 ## v1.1.0
 
-- Date: **2022-10-XX**
+- Date: **2022-10-28**
 - [Diff between v1.1.0 and v1.0.3](https://github.com/sigven/pcgr/compare/v1.0.3...v1.1.0)
 
 ### Changes
@@ -17,17 +27,17 @@ output: rmarkdown::html_document
   - `--version` CLI argument added for `pcgr/cpsr.py`
   - declutter repetitive log messages
   - refactor `pcgr/cpsr.py` script
-- Update documentation and declutter logging; refactor dict creation ([pr192](https://github.com/sigven/pcgr/pull/192))
+- Update documentation and declutter logging; refactor dict creation ([pr192](https://github.com/sigven/pcgr/pull/192)).
 - Minor refactor ([pr194](https://github.com/sigven/pcgr/pull/194)):
   - switch to using Python's native `os.remove` and `os.rename` for glob cleanup
   - keep decompressed VCF only if `--vcf2maf` option is specified.
     The [vcf2maf](https://github.com/mskcc/vcf2maf) tool does not support compressed VCFs - see
     [issue235](https://github.com/mskcc/vcf2maf/issues/235).
-- Fix for CLI argument `--cna_overlap_pct` ([pr196](https://github.com/sigven/pcgr/pull/196).
+- Fix for CLI argument `--cna_overlap_pct` ([pr196](https://github.com/sigven/pcgr/pull/196)).
 
 ### New Contributors
 
-- [@niklasmueboe](https://github.com/niklasmueboe) ([pr196](https://github.com/sigven/pcgr/pull/196).
+- [@niklasmueboe](https://github.com/niklasmueboe) ([pr196](https://github.com/sigven/pcgr/pull/196)).
 
 ## v1.0.3
 

--- a/scripts/cpsr_validate_input.py
+++ b/scripts/cpsr_validate_input.py
@@ -227,20 +227,13 @@ def simplify_vcf(input_vcf, vcf, custom_bed, pcgr_directory, genome_assembly, vi
          variant_id = f"{rec.CHROM}:{POS}_{rec.REF}->{alt}"
          multiallelic_list.append(variant_id)
 
-   is_gzipped = True if input_vcf.endswith('.gz') else False
-   cat_vcf = f"bgzip -dc {input_vcf}" if is_gzipped else f"cat {input_vcf}"
+   # Grab metadata lines
+   cmd_vcf1 = f'bcftools view -h {input_vcf} > {input_vcf_cpsr_ready}'
+   # Now sort VCF and keep only auto/XY/M/MT
+   cmd_vcf2 = f'bcftools sort {input_vcf} | bcftools view -H | sed \'s/^chr//\' | grep -w \'^[1-9]\|^[1-2][0-9]\|^[XYM]\|^MT\' >> {input_vcf_cpsr_ready}'
 
-   command_vcf_sample_free1 = f'{cat_vcf} | egrep \'^##\' > {input_vcf_cpsr_ready}'
-   command_vcf_sample_free2 = f'{cat_vcf} | egrep \'^#CHROM\' >> {input_vcf_cpsr_ready}'
-   command_vcf_sample_free3 = f'{cat_vcf} | egrep -v \'^#\' | sed \'s/^chr//\' | egrep \'^[0-9]\' | sort -k1,1n -k2,2n -k4,4 -k5,5 >> {input_vcf_cpsr_ready}'
-   command_vcf_sample_free4 = f'{cat_vcf} | egrep -v \'^#\' | sed \'s/^chr//\' | egrep -v \'^[0-9]\' | egrep \'^[XYM]\' | sort -k1,1 -k2,2n -k4,4 -k5,5 >> {input_vcf_cpsr_ready}'
-   command_vcf_sample_free5 = f'{cat_vcf} | egrep -v \'^#\' | sed \'s/^chr//\' | egrep -v \'^[0-9]\' | egrep -v \'^[XYM]\' | sort -k1,1 -k2,2n -k4,4 -k5,5 >> {input_vcf_cpsr_ready}'
-
-   check_subprocess(logger, command_vcf_sample_free1, debug)
-   check_subprocess(logger, command_vcf_sample_free2, debug)
-   check_subprocess(logger, command_vcf_sample_free3, debug)
-   check_subprocess(logger, command_vcf_sample_free4, debug)
-   check_subprocess(logger, command_vcf_sample_free5, debug)
+   check_subprocess(logger, cmd_vcf1, debug)
+   check_subprocess(logger, cmd_vcf2, debug)
 
    if multiallelic_list:
       logger.warning(f"There were {len(multiallelic_list)} multiallelic sites detected. Showing (up to) the first 100:")

--- a/scripts/cpsr_validate_input.py
+++ b/scripts/cpsr_validate_input.py
@@ -228,7 +228,7 @@ def simplify_vcf(input_vcf, vcf, custom_bed, pcgr_directory, genome_assembly, vi
          multiallelic_list.append(variant_id)
 
    is_gzipped = True if input_vcf.endswith('.gz') else False
-   cat_vcf = f"bgzip -dc {input_vcf}" if is_gzipped else "cat {input_vcf}"
+   cat_vcf = f"bgzip -dc {input_vcf}" if is_gzipped else f"cat {input_vcf}"
 
    command_vcf_sample_free1 = f'{cat_vcf} | egrep \'^##\' > {input_vcf_cpsr_ready}'
    command_vcf_sample_free2 = f'{cat_vcf} | egrep \'^#CHROM\' >> {input_vcf_cpsr_ready}'

--- a/scripts/cpsr_validate_input.py
+++ b/scripts/cpsr_validate_input.py
@@ -213,7 +213,9 @@ def simplify_vcf(input_vcf, vcf, custom_bed, pcgr_directory, genome_assembly, vi
    4. Final VCF file is sorted and indexed (bgzip + tabix)
    """
 
-   input_vcf_cpsr_ready = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)','.cpsr_ready.tmp.vcf', os.path.basename(input_vcf)))
+   tmp_vcf1 = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)', '.cpsr_ready.tmp1.vcf', os.path.basename(input_vcf)))
+   tmp_vcf2 = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)', '.cpsr_ready.tmp2.vcf.gz', os.path.basename(input_vcf)))
+   tmp_vcf3 = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)', '.cpsr_ready.tmp3.vcf.gz', os.path.basename(input_vcf)))
    input_vcf_cpsr_ready_decomposed = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)','.cpsr_ready.vcf', os.path.basename(input_vcf)))
    input_vcf_cpsr_ready_decomposed_target = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)','.cpsr_ready_target.vcf', os.path.basename(input_vcf)))
    virtual_panels_tmp_bed = os.path.join(output_dir, "virtual_panels_all." + str(sample_id) + ".tmp.bed")
@@ -227,10 +229,13 @@ def simplify_vcf(input_vcf, vcf, custom_bed, pcgr_directory, genome_assembly, vi
          variant_id = f"{rec.CHROM}:{POS}_{rec.REF}->{alt}"
          multiallelic_list.append(variant_id)
 
-   # Grab metadata lines
-   cmd_vcf1 = f'bcftools view -h {input_vcf} > {input_vcf_cpsr_ready}'
-   # Now sort VCF and keep only auto/XY/M/MT
-   cmd_vcf2 = f'bcftools sort {input_vcf} | bcftools view -H | sed \'s/^chr//\' | grep -w \'^[1-9]\|^[1-2][0-9]\|^[XYM]\|^MT\' >> {input_vcf_cpsr_ready}'
+   # bgzip + tabix required for sorting
+   cmd_vcf1 = f'bcftools view {input_vcf} | bgzip -cf > {tmp_vcf2} && tabix -p vcf {tmp_vcf2} && bcftools sort -Oz {tmp_vcf2} > {tmp_vcf3} && tabix -p vcf {tmp_vcf3}'
+
+   # Keep only autosomal/sex/mito chrom (handle hg38 and hg19), sub chr prefix
+   chrom_to_keep = [str(x) for x in [*range(1,23), 'X', 'Y', 'M', 'MT']]
+   chrom_to_keep = ','.join([*['chr' + chrom for chrom in chrom_to_keep], *[chrom for chrom in chrom_to_keep]])
+   cmd_vcf2 = f'bcftools view --regions {chrom_to_keep} {tmp_vcf3} | sed \'s/^chr//\' > {tmp_vcf1}'
 
    check_subprocess(logger, cmd_vcf1, debug)
    check_subprocess(logger, cmd_vcf2, debug)
@@ -241,10 +246,10 @@ def simplify_vcf(input_vcf, vcf, custom_bed, pcgr_directory, genome_assembly, vi
       print(', '.join(multiallelic_list[:100]))
       print('----')
       logger.info('Decomposing multi-allelic sites in input VCF file using \'vt decompose\'')
-      command_decompose = f'vt decompose -s {input_vcf_cpsr_ready} > {input_vcf_cpsr_ready_decomposed}  2> {os.path.join(output_dir, "decompose.log")}'
+      command_decompose = f'vt decompose -s {tmp_vcf1} > {input_vcf_cpsr_ready_decomposed} 2> {os.path.join(output_dir, "decompose.log")}'
       check_subprocess(logger, command_decompose, debug)
    else:
-      command_copy = f'cp {input_vcf_cpsr_ready} {input_vcf_cpsr_ready_decomposed}'
+      command_copy = f'cp {tmp_vcf1} {input_vcf_cpsr_ready_decomposed}'
       check_subprocess(logger, command_copy, debug)
 
 
@@ -284,7 +289,7 @@ def simplify_vcf(input_vcf, vcf, custom_bed, pcgr_directory, genome_assembly, vi
    check_subprocess(logger, f'bgzip -cf {input_vcf_cpsr_ready_decomposed_target} > {input_vcf_cpsr_ready_decomposed_target}.gz', debug)
    check_subprocess(logger, f'tabix -p vcf {input_vcf_cpsr_ready_decomposed_target}.gz', debug)
    if not debug:
-      for fn in [input_vcf_cpsr_ready, virtual_panels_bed, input_vcf_cpsr_ready_decomposed, os.path.join(output_dir, "decompose.log")]:
+      for fn in [tmp_vcf1, tmp_vcf2, tmp_vcf3,  virtual_panels_bed, input_vcf_cpsr_ready_decomposed, os.path.join(output_dir, "decompose.log")]:
          #print(f"Deleting {fn}")
          utils.remove(fn)
 

--- a/scripts/pcgr_validate_input.py
+++ b/scripts/pcgr_validate_input.py
@@ -383,7 +383,7 @@ def simplify_vcf(input_vcf, vcf, output_dir, keep_uncompressed, logger, debug):
             multiallelic_list.append(variant_id)
 
     is_gzipped = True if input_vcf.endswith('.gz') else False
-    cat_vcf = f"bgzip -dc {input_vcf}" if is_gzipped else "cat {input_vcf}"
+    cat_vcf = f"bgzip -dc {input_vcf}" if is_gzipped else f"cat {input_vcf}"
     # Remove FORMAT metadata lines
     command_vcf_sample_free1 = f'{cat_vcf} | egrep \'^##\' | egrep -v \'^##FORMAT=\' > {input_vcf_pcgr_ready}'
     # Output first 8 column names (CHROM-INFO, so ignore FORMAT + sample columns)

--- a/scripts/pcgr_validate_input.py
+++ b/scripts/pcgr_validate_input.py
@@ -365,13 +365,17 @@ def check_format_ad_dp_tags(vcf,
 
 def simplify_vcf(input_vcf, vcf, output_dir, keep_uncompressed, logger, debug):
     """
+    input_vcf: path to input VCF
+    vcf: parsed cyvcf2 object
     Function that performs the following on the validated input VCF:
     1. Strip of any genotype data
     2. If VCF has variants with multiple alternative alleles ("multiallelic", e.g. 'A,T'), these are decomposed into variants with a single alternative allele
     3. Final VCF file is sorted and indexed (bgzip + tabix)
     """
 
-    input_vcf_pcgr_ready = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)', '.pcgr_ready.tmp.vcf', os.path.basename(input_vcf)))
+    tmp_vcf1 = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)', '.pcgr_ready.tmp1.vcf', os.path.basename(input_vcf)))
+    tmp_vcf2 = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)', '.pcgr_ready.tmp2.vcf.gz', os.path.basename(input_vcf)))
+    tmp_vcf3 = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)', '.pcgr_ready.tmp3.vcf.gz', os.path.basename(input_vcf)))
     input_vcf_pcgr_ready_decomposed = os.path.join(output_dir, re.sub(r'(\.vcf$|\.vcf\.gz$)', '.pcgr_ready.vcf', os.path.basename(input_vcf)))
 
     multiallelic_list = list()
@@ -382,16 +386,15 @@ def simplify_vcf(input_vcf, vcf, output_dir, keep_uncompressed, logger, debug):
             variant_id = f"{rec.CHROM}:{POS}_{rec.REF}->{alt}"
             multiallelic_list.append(variant_id)
 
-    # Remove FORMAT metadata lines
-    cmd_vcf1 = f'bcftools view -h {input_vcf} | egrep \'^##\' | egrep -v \'^##FORMAT=\' > {input_vcf_pcgr_ready}'
-    # Keep cols 1-8 for #CHROM row
-    cmd_vcf2 = f'bcftools view -h {input_vcf} | egrep \'^#CHROM\' | cut -f1-8 >> {input_vcf_pcgr_ready}'
-    # Now sort VCF and keep only auto/XY/M/MT
-    cmd_vcf3 = f'bcftools sort {input_vcf} | bcftools view -H | sed \'s/^chr//\' | grep -w \'^[1-9]\|^[1-2][0-9]\|^[XYM]\|^MT\' | cut -f1-8 >> {input_vcf_pcgr_ready}'
+    # bgzip + tabix required for sorting
+    cmd_vcf1 = f'bcftools view {input_vcf} | bgzip -cf > {tmp_vcf2} && tabix -p vcf {tmp_vcf2} && bcftools sort -Oz {tmp_vcf2} > {tmp_vcf3} && tabix -p vcf {tmp_vcf3}'
+    # Keep only autosomal/sex/mito chrom (handle hg38 and hg19), remove FORMAT metadata lines, keep cols 1-8, sub chr prefix
+    chrom_to_keep = [str(x) for x in [*range(1,23), 'X', 'Y', 'M', 'MT']]
+    chrom_to_keep = ','.join([*['chr' + chrom for chrom in chrom_to_keep], *[chrom for chrom in chrom_to_keep]])
+    cmd_vcf2 = f'bcftools view --regions {chrom_to_keep} {tmp_vcf3} | egrep -v \'^##FORMAT=\' | cut -f1-8 | sed \'s/^chr//\' > {tmp_vcf1}'
 
     check_subprocess(logger, cmd_vcf1, debug)
     check_subprocess(logger, cmd_vcf2, debug)
-    check_subprocess(logger, cmd_vcf3, debug)
 
     if multiallelic_list:
         logger.warning(f"There were {len(multiallelic_list)} multiallelic sites detected. Showing (up to) the first 100:")
@@ -399,11 +402,11 @@ def simplify_vcf(input_vcf, vcf, output_dir, keep_uncompressed, logger, debug):
         print(', '.join(multiallelic_list[:100]))
         print('----')
         logger.info('Decomposing multi-allelic sites in input VCF file using \'vt decompose\'')
-        command_decompose = f'vt decompose -s {input_vcf_pcgr_ready} > {input_vcf_pcgr_ready_decomposed} 2> {os.path.join(output_dir, "decompose.log")}'
+        command_decompose = f'vt decompose -s {tmp_vcf1} > {input_vcf_pcgr_ready_decomposed} 2> {os.path.join(output_dir, "decompose.log")}'
         check_subprocess(logger, command_decompose, debug)
     else:
         logger.info('All sites seem to be decomposed - skipping decomposition!')
-        check_subprocess(logger, f'cp {input_vcf_pcgr_ready} {input_vcf_pcgr_ready_decomposed}', debug)
+        check_subprocess(logger, f'cp {tmp_vcf1} {input_vcf_pcgr_ready_decomposed}', debug)
 
     # need to keep uncompressed copy for vcf2maf.pl if selected
     bgzip_cmd = f"bgzip -cf {input_vcf_pcgr_ready_decomposed} > {input_vcf_pcgr_ready_decomposed}.gz" if keep_uncompressed else f"bgzip -f {input_vcf_pcgr_ready_decomposed}"
@@ -421,7 +424,8 @@ def simplify_vcf(input_vcf, vcf, output_dir, keep_uncompressed, logger, debug):
             logger.info('')
             exit(1)
 
-    utils.remove(input_vcf_pcgr_ready)
+    utils.remove(tmp_vcf1)
+    utils.remove(tmp_vcf2)
     utils.remove(os.path.join(output_dir, "decompose.log"))
 
 def validate_pcgr_input(pcgr_directory,


### PR DESCRIPTION
- Using bcftools for initial VCF parsing and sorting in the `scripts/*_validate_input.py` scripts. This also means we don't need to worry about the input VCF being zipped or unzipped, since bcftools handles both.
- Keeping only autosomal, X, Y and M/MT chromosomes (i.e. discarding variants on alt contigs).

My tests seem to work, hopefully we shouldn't have corner cases for these relatively simple changes. `bcftools sort` goes with 1-22, X, Y, M (--edit: actually, it works based on the contig order in the metadata ;-)).
@sigven please sanity check those filters, the logic seems to match what we had previously.