### PR TITLE
Better handling of pcgr/pcgrr conda env custom naming

### DIFF
--- a/pcgr/cpsr.py
+++ b/pcgr/cpsr.py
@@ -320,8 +320,9 @@ def run_cpsr(arg_dict, cpsr_paths):
 
         # export PATH to R conda env Rscript
         pcgrr_conda = arg_dict['pcgrr_conda']
+        pcgr_conda = utils.conda_prefix_basename()
         rscript = utils.script_path(pcgrr_conda, 'bin/Rscript')
-        cpsrr_script = utils.script_path('pcgr', 'bin/cpsr.R')
+        cpsrr_script = utils.script_path(pcgr_conda, 'bin/cpsr.R')
         cpsr_report_command = (
                 f"{rscript} {cpsrr_script} "
                 f"{output_dir} "

--- a/pcgr/main.py
+++ b/pcgr/main.py
@@ -438,8 +438,9 @@ def run_pcgr(pcgr_paths, config_options):
 
         # export PATH to R conda env Rscript
         pcgrr_conda = config_options['pcgrr_conda']
+        pcgr_conda = utils.conda_prefix_basename()
         rscript = utils.script_path(pcgrr_conda, 'bin/Rscript')
-        pcgrr_script = utils.script_path('pcgr', 'bin/pcgrr.R')
+        pcgrr_script = utils.script_path(pcgr_conda, 'bin/pcgrr.R')
         pcgr_report_command = (
                 f"{rscript} {pcgrr_script} "
                 f"{output_dir} "


### PR DESCRIPTION
Adding better support for custom naming of pcgr/pcgrr conda envs.

In short, we use the `$CONDA_PREFIX` variable to point us to the name of the main 'pcgr' conda env that is used to run the analysis. 

With the `--pcgrr_conda` option (default: `pcgrr`), you're being explicit that the 'pcgrr' conda env will have a non-default name (e.g. `baz_pcgrr`).


```
$ echo $CONDA_PREFIX
/path/to/conda/foo_pcgr
```

Based on the above path, the main 'pcgr' conda env is called `foo_pcgr`. And there should be a `baz_pcgrr` directory sitting at the same level as `foo_pcgr`.
These names/paths are important since they're used to call Rscript from the pcgrr conda env and to point to perl and loftee binaries/directories.
