### PR TITLE
Bump r-base to 4.3.3

### DIFF
--- a/.github/workflows/build_conda_recipes.yaml
+++ b/.github/workflows/build_conda_recipes.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - bundle_update_2023
-      - conda_deps
+      - conda_deps2
 env:
   atoken: ${{ secrets.ANACONDA_UPLOAD_TOKEN }}
   recipe_path: conda/recipe

--- a/.github/workflows/build_conda_recipes.yaml
+++ b/.github/workflows/build_conda_recipes.yaml
@@ -30,7 +30,7 @@ jobs:
           environment-file: ${{ env.env_yml_path }}/condabuild.yml
       - name: 🐍 Conda pkg build and upload
         run: |
-          conda mambabuild ${recipe_path}/pcgrr -c umccr -c conda-forge -c bioconda --token ${atoken}
+          conda mambabuild ${recipe_path}/pcgrr -c conda-forge -c bioconda --token ${atoken}
   build_pcgr_conda_pkg:
     # When merging to one of the branches above and the commit message matches
     if: "startsWith(github.event.head_commit.message, 'Bump version:')"

--- a/conda/recipe/pcgrr/build.sh
+++ b/conda/recipe/pcgrr/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export DISABLE_AUTOBREW=1
-${R} -e "install.packages('devtools', repos = 'https://cloud.r-project.org/', lib = '${PREFIX}/lib/R/library')"
+${R} -e "install.packages('remotes', repos = 'https://cloud.r-project.org/', lib = '${PREFIX}/lib/R/library')"
 ${R} -e "install.packages('openxlsx2', repos = 'https://cloud.r-project.org/', lib = '${PREFIX}/lib/R/library')"
-${R} -e "devtools::install_github(repo = 'caravagnalab/CNAqc', ref = '274cde9', lib = '${PREFIX}/lib/R/library')"
+${R} -e "remotes::install_github(repo = 'caravagnalab/CNAqc', ref = '274cde9', lib = '${PREFIX}/lib/R/library')"
 ${R} CMD INSTALL --build . ${R_ARGS}

--- a/conda/recipe/pcgrr/meta.yaml
+++ b/conda/recipe/pcgrr/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   build:
     - git
   host:
-    - r-base ==4.2.3
+    - r-base ==4.3.3
     - r-assertable
     - r-assertthat
     - bioconductor-biostrings
@@ -48,7 +48,7 @@ requirements:
     - r-yaml
 
   run:
-    - r-base ==4.2.3
+    - r-base ==4.3.3
     - r-assertable
     - r-assertthat
     - bioconductor-biostrings


### PR DESCRIPTION
- r-base can be bumped to 4.3.3
- using remotes instead of devtools

Both above cut the pcgrr conda pkg build time by 7min (to 16min from 23min).

- also removing pcgr/umccr personal channels since the pcgrr pkg build does not need cpsr any more