### PR TITLE
Update conda recipe

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -23,6 +23,10 @@ replace = __version__ = '{new_version}'
 search = version = "{current_version}"
 replace = version = "{new_version}"
 
+[bumpversion:file:conda/recipe/pcgr/meta.yaml]
+search = version: {current_version}
+replace = version: {new_version}
+
 [bumpversion:file:conda/recipe/pcgrr/meta.yaml]
 search = version: {current_version}
 replace = version: {new_version}

--- a/conda/recipe/pcgr/meta.yaml
+++ b/conda/recipe/pcgr/meta.yaml
@@ -1,8 +1,6 @@
-{% set data = load_setup_py_data() %}
-
 package:
   name: pcgr
-  version: {{ data.get('version') }}
+  version: 1.4.1.9004 # versioned by bump2version
 
 source:
   path: ../../..
@@ -32,6 +30,6 @@ test:
     - pcgr --version
 
 about:
-  home: {{ data.get('url') }}
-  license: {{ data.get('license') }}
-  summary: {{ data.get('description') }}
+  home: https://github.com/sigven/pcgr
+  license: MIT
+  summary: Personal Cancer Genome Reporter (PCGR) - variant interpretation for precision cancer medicine.


### PR DESCRIPTION
The `data` construct in the pcgr conda recipe's `meta.yaml` returns None so we should hardcode values instead. I think this is due to our change to `pyproject.toml` setup in #222.