### PR TITLE
Docker: use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN mamba create -n pcgr --file ${PCGR_CONDA_ENV_DIR}/pcgr-linux-64.lock
 RUN mamba create -n pcgrr --file ${PCGR_CONDA_ENV_DIR}/pcgrr-linux-64.lock
 RUN mamba clean --all --force-pkgs-dirs --yes
 
+FROM quay.io/bioconda/base-glibc-busybox-bash:3.1
+
+COPY --from=0 /opt/mambaforge/envs/ /opt/mambaforge/envs/
+
 ARG PCGR_ENV_NAME="pcgr"
 # pcgr env is activated by default
 ENV PATH="/opt/mambaforge/envs/${PCGR_ENV_NAME}/bin:${PATH}"


### PR DESCRIPTION
Fixes #234 

Based on my local tests, the image size goes from 7.95 down to 5.65 gigs.

Using this as the base image: https://github.com/bioconda/bioconda-containers/tree/main/images/base-glibc-busybox-bash