### PR TITLE
Set locale to avoid apptainer warnings on HPC

### DIFF
--- a/.github/workflows/build_conda_recipes.yaml
+++ b/.github/workflows/build_conda_recipes.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - bundle_update_2023
+      - locale
 env:
   atoken: ${{ secrets.ANACONDA_UPLOAD_TOKEN }}
   recipe_path: conda/recipe
@@ -85,6 +86,7 @@ jobs:
           git commit -m "${MSG}"
           git push
       - name: 🌐 Website publish
+        if: github.ref_name == 'master'
         run: |
           micromamba env create -n pkgdownenv -f ${env_yml_path}/pkgdown.yml
           micromamba activate pkgdownenv

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ FROM quay.io/bioconda/base-glibc-busybox-bash:3.1
 
 COPY --from=0 /opt/mambaforge/envs/ /opt/mambaforge/envs/
 
+ENV LANGUAGE='C.UTF-8'
+ENV LANG='C.UTF-8'
+ENV LC_ALL='C.UTF-8'
+
 ARG PCGR_ENV_NAME="pcgr"
 # pcgr env is activated by default
 ENV PATH="/opt/mambaforge/envs/${PCGR_ENV_NAME}/bin:${PATH}"

--- a/pcgr/main.py
+++ b/pcgr/main.py
@@ -109,7 +109,6 @@ def cli():
     optional_cna.add_argument("--input_cna", dest="input_cna", help="Somatic copy number alteration segments (tab-separated values)")
     optional_cna.add_argument("--n_copy_gain", type=int, default=6, dest="n_copy_gain", help="Minimum number of total copy number for segments considered as gains/amplifications (default: %(default)s)")
     optional_cna.add_argument("--cna_overlap_pct", type=float, default=50, dest="cna_overlap_pct", help="Mean percent overlap between copy number segment and gene transcripts for reporting of gains/losses in tumor suppressor genes/oncogenes, (default: %(default)s)")
-
     #optional_rna.add_argument("--input_rna_fusion", dest = "input_rna_fusion", help = "File with RNA fusion transcripts detected in tumor (tab-separated values)")
     optional_rna.add_argument("--input_rna_expression", dest = "input_rna_exp", help = "File with bulk RNA expression counts (TPM) of transcripts in tumor (tab-separated values)")
     optional_rna.add_argument('--expression_sim', action='store_true', help="Compare expression profile of tumor sample to known expression profiles (default: %(default)s)")
@@ -130,6 +129,12 @@ def cli():
     optional_other.add_argument("--no_reporting", action="store_true", help="Run functional variant annotation on VCF through VEP/vcfanno, omit other analyses (i.e. Tier assignment/MSI/TMB/Signatures etc. and report generation (STEP 4), default: %(default)s")
     optional_other.add_argument("--debug", action="store_true", help="Print full commands to log")
     optional_other.add_argument("--pcgrr_conda", default="pcgrr", help="pcgrr conda env name (default: %(default)s)")
+
+    # Set locale since apptainer on HPC gives warnings
+    locale_to_use = utils.get_locale()
+    os.environ["LC_ALL"] = locale_to_use
+    os.environ["LC"] = locale_to_use
+    os.environ["LANG"] = locale_to_use
 
     # Parse required and optional arguments
     args = parser.parse_args()

--- a/pcgr/main.py
+++ b/pcgr/main.py
@@ -131,10 +131,10 @@ def cli():
     optional_other.add_argument("--pcgrr_conda", default="pcgrr", help="pcgrr conda env name (default: %(default)s)")
 
     # Set locale since apptainer on HPC gives warnings
-    locale_to_use = utils.get_locale()
-    os.environ["LC_ALL"] = locale_to_use
-    os.environ["LC"] = locale_to_use
-    os.environ["LANG"] = locale_to_use
+    #locale_to_use = utils.get_locale()
+    #os.environ["LANGUAGE"] = locale_to_use
+    #os.environ["LANG"] = locale_to_use
+    #os.environ["LC_ALL"] = locale_to_use
 
     # Parse required and optional arguments
     args = parser.parse_args()

--- a/pcgr/utils.py
+++ b/pcgr/utils.py
@@ -36,9 +36,9 @@ def warn_message(message, logger):
     logger.warning("")
     logger.warning(message)
     logger.warning("")
- 
+
 def random_id_generator(size = 10, chars = string.ascii_lowercase + string.digits):
-    return ''.join(random.choice(chars) for _ in range(size))   
+    return ''.join(random.choice(chars) for _ in range(size))
 
 #def random_string(length):
 #    letters = string.ascii_lowercase
@@ -166,7 +166,7 @@ def safe_makedir(dname):
     return dname
 
 def sort_bed(unsorted_bed_fname: str, sorted_bed_fname: str, debug = False, logger = None):
-    
+
     ## Sort regions in target BED
     if os.path.exists(unsorted_bed_fname) and os.stat(unsorted_bed_fname).st_size != 0:
         cmd_sort_custom_bed1 = 'egrep \'^[0-9]\' ' + str(unsorted_bed_fname) + \
@@ -197,7 +197,6 @@ def check_file_exists(fname: str, strict = True, logger = None) -> bool:
             return(False)
         else:
             error_message(msg, logger)
-    
     return(True)
 
 def check_tabix_file(fname: str, logger = None) -> bool:
@@ -210,3 +209,41 @@ def check_tabix_file(fname: str, logger = None) -> bool:
         ## check file size is more than zero
         check_file_exists(tabix_file)
     return(True)
+
+def locale_export():
+    """
+    https://github.com/bcbio/bcbio-nextgen/blob/855c7ae/bcbio/utils.py#L885
+    """
+    locale_to_use = get_locale()
+    return f"export LC_ALL={locale_to_use} && export LANG={locale_to_use} && "
+
+def get_locale():
+    """
+    https://github.com/bcbio/bcbio-nextgen/blob/855c7ae/bcbio/utils.py#L895
+    Looks up available locales on the system to find an appropriate one to pick,
+    defaulting to C.UTF-8 which is globally available on newer systems. Prefers
+    C.UTF-8 and en_US encodings, if available
+    """
+    default_locale = "C.UTF-8"
+    preferred_locales = {"c.utf-8", "c.utf8", "en_us.utf-8", "en_us.utf8"}
+    locale_to_use = None
+    try:
+        locales = subprocess.check_output(["locale", "-a"]).decode(errors="ignore").split("\n")
+    except subprocess.CalledProcessError:
+        locales = []
+    # check for preferred locale
+    for locale in locales:
+        if locale.lower() in preferred_locales:
+            locale_to_use = locale
+            break
+    # if preferred locale not available take first UTF-8 locale
+    if not locale_to_use:
+        for locale in locales:
+            if locale.lower().endswith(("utf-8", "utf8")):
+                locale_to_use = locale
+                break
+    # if locale listing not available, try using the default locale
+    if not locale_to_use:
+        locale_to_use = default_locale
+    return locale_to_use
+


### PR DESCRIPTION
This is to hopefully help with the following warning we're getting after using Singularity on HPC:

```
warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```

We're setting the `LC_ALL`, `LANGUAGE` and `LANG` within the Docker build for starters.