### PR TITLE
use samtools > v1 (for vcf2maf)

### DIFF
--- a/conda/env/yaml/pcgr.yaml
+++ b/conda/env/yaml/pcgr.yaml
@@ -13,6 +13,7 @@ dependencies:
   - conda-forge::pandoc
   - bioconda::perl-bio-bigfile
   - conda-forge::perl-compress-raw-zlib
+  - bioconda::samtools >=1.0
   - bioconda::vcfanno
   - bioconda::vt
   - bioconda::vcf2maf


### PR DESCRIPTION
Fixes #297.
I did a local conda-lock and the samtools v1 requirement forces conda to pull in the samtools-less perl-bio-samtools which is what we want.
@sigven I think this is critical enough to be merged straight into main and we should make a new patch release v2.3.1